### PR TITLE
XAWORKFLOW-71: Can't start a new workflow on pages with no parent

### DIFF
--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
@@ -573,8 +573,8 @@ document.observe('xwiki:dom:loading', function() {
             #end
           #end
         #end
-        #set($targetAlreadyExists = "$!request.targetexists" == 'true' || ($targetRef &amp;&amp; $xwiki.exists($targetRef)))
-        #if($targetAlreadyExists)
+        #set ($targetAlreadyContainsAWorkflow = ("$!request.targetexists" == 'true'))
+        #if ($targetAlreadyContainsAWorkflow)
           &lt;div class="xHint warningmessage targetexists"&gt;&lt;div class="warning"&gt;$services.localization.render('workflow.start.targetExists')&lt;/div&gt;&lt;/div&gt;
         #end
         ## Advanced options link.
@@ -621,7 +621,7 @@ document.observe('xwiki:dom:loading', function() {
         #else
           #set($targetDocRef = $services.model.createDocumentReference($targetDocName, $parentReference))
         #end
-        #set($showDetails = $targetAlreadyExists || $!request.same == 'true' || $xwiki.exists($targetDocRef))
+        #set ($showDetails = $targetAlreadyContainsAWorkflow || $!request.same == 'true' || $xwiki.exists($targetDocRef))
         &lt;div id="workflow-options-container" class="collapse #if($showDetails) in#end"&gt;
           ## Display the location picker.
           #template('locationPicker_macros.vm')

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
@@ -80,8 +80,6 @@
   #if($request.cancel)  
     $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', ''))
   #end
-  ## workflow doc ref: $workflowDocRef
-  ## Action : $action
   #if($action == "start")
     #set ($targetSpaceReferencePath = "$!request.targetSpace")
     #set ($targetName = "$!request.targetName")
@@ -91,15 +89,16 @@
       #set ($targetSpaceReference = $services.model.createSpaceReference($targetName, $targetSpaceReference))
       #set ($targetReference = $services.model.createDocumentReference($defaultSpaceHomePageName, $targetSpaceReference))
     #else
-      #set ($targetSpaceReference = $services.model.resolveSpace($targetSpaceReferencePath))
-      #set ($targetReference = $services.model.createDocumentReference($targetName, $targetSpaceReference))
+      ## #createDocumentReference(name, space) is available from 7.2M2.
+      #set ($targetReference = $services.model.createDocumentReference('', $targetSpaceReferencePath, $targetName))
     #end
     #set($workflowConfig = "$request.workflow")
     ## Check that the target and the existing doc are different
     #if($targetReference.equals($workflowDocRef))
       $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', 'same=true'))
-    ## Check that the target does not exist
-    #elseif($xwiki.exists($targetReference))
+    ## Check if the target is not already a published page in a workflow.
+    ## Although this check is already done in services.publicationworkflow#startWorkflow, we should display the reason of the error.
+    #elseif ($services.publicationworkflow.isWorkflowDocument($targetReference))
       $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', 'targetexists=true'))
     #else
       #set($result = $services.publicationworkflow.startWorkflow($workflowDocRef, $workflowConfig, $targetReference))


### PR DESCRIPTION
* The published page should exist in any case, so the right way is to check if the targetPage is already in a workflow.