### PR TITLE
XAWORKFLOW-57: Include an option to include children when publishing a ND draft

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
 <!--
- *
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
  *
@@ -18,24 +18,21 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- *
 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.xwiki.commons</groupId>
-    <artifactId>xwiki-commons-pom</artifactId>
-    <version>7.2</version>
+    <groupId>org.xwiki.contrib</groupId>
+    <artifactId>parent-platform</artifactId>
+    <version>12.10.4</version>
   </parent>
   <groupId>org.xwiki.contrib.workflow-publication</groupId>
   <artifactId>xwiki-workflow-publication</artifactId>
   <name>Publication Workflow Application</name>
   <description>Simple publication workflow implementation that allows to push a document through various validation states until it is published.</description>
   <packaging>pom</packaging>
-  <version>1.11-SNAPSHOT</version>
-  <properties>
-    <xwiki.platform.version>${commons.version}</xwiki.platform.version>
-  </properties>
+  <version>2.0-SNAPSHOT</version>
   <developers>
     <developer>
       <id>lucaa</id>
@@ -48,7 +45,11 @@
     <developer>
       <id>rstavro</id>
       <name>Raluca Stavro</name>
-    </developer>    
+    </developer>
+    <developer>
+      <id>slauriere</id>
+      <name>slauriere</name>
+    </developer>
   </developers>
   <issueManagement>
     <system>jira</system>

--- a/tests.md
+++ b/tests.md
@@ -8,7 +8,7 @@
 
 ### Scenario
 
-* Create page in multiple languages with links to other drafts
+* Create page in multiple languages with links to other drafts.
 * Initialize workflow on that page
 * Submit page to moderation, then to validation
 * Publish page
@@ -21,8 +21,8 @@
 * The draft page is marked as hidden
 * Page rights are updated on each transition along the chosen workflow configuration groups
 * The publish action creates a page at the expected location, with translations
-* The published page links referring to pages under workflow point at published pages, not at draft ones, in the default
- page as well as in the translations, even if the drafts are not published yet
+* The published page links referring to pages under workflow point at published pages, in the default page as well as
+ in the translations, even if the drafts are not published yet
 * On second publication, the rights set on the published page are not overriden
 * When a translation gets removed from the draft, the corresponding published translation gets removed on next publish
 * On page archiving, the page and all its translations become hidden
@@ -32,12 +32,12 @@
 ### Scenario
 
 * Create page in multiple languages containing both non-terminal and terminal children, with at least 3 hierarchy
- levels, with links to other drafts under the same workflow or in other workflows, pointing at either terminal or non
--terminal pages, either workflow root pages or child pages.
+ levels, with links to other drafts under the same workflow or in other workflows, pointing at either terminal or 
+ non-terminal pages, either workflow root pages or child pages
 * Initialize workflow on that page and check the "include children" option
 * Submit page to moderation, then to validation
 * Publish page
-* Remove some children from draft, then republish
+* Remove some children and grandchildren from draft, then republish
 * Add rights to the published page hierarchy, then republish
 * Archive page
 * Publish page from archive
@@ -45,11 +45,12 @@
 ### Expected results
 
 * Page draft and its children are marked as hidden
-* Page hierarchical rights (WebPreferences) are updated on each transition along the chosen workflow configuration
- groups
-* The publish action creates a page at the expected location with its children published as well and its grandchildren
+* Page hierarchical rights (global rights in `WebPreferences`) are updated on each transition along the chosen workflow
+ configuration groups
+* The publish action creates a page at the expected location with its children and grandchildren published as well, 
+ and with a history message reflecting the publish action
 * Links in the published pages pointing at pages which are under workflow point exclusively at published pages, not
- draft ones, even if the drafts are not published yet.
+ draft ones, even if the drafts are not published yet
 * When draft page children or grandchildren get removed, the corresponding published children or grandchildren get
  removed on next publish
 * When rights are updated on the published page hierarchy, they are preserved on next publish
@@ -67,4 +68,4 @@
 ### Expected results
 
 * Local rights are used on the draft page, not hierarchical ones
-* The page gets published, but not its children
+* On publish, the page under workflow gets published, but not its children

--- a/tests.md
+++ b/tests.md
@@ -8,7 +8,7 @@
 
 ### Scenario
 
-* Create page in multiple languages with links to other drafts.
+* Create page in multiple languages with links to other drafts in the same wiki and in a distinct wiki.
 * Initialize workflow on that page
 * Submit page to moderation, then to validation
 * Publish page
@@ -33,7 +33,7 @@
 
 * Create page in multiple languages containing both non-terminal and terminal children, with at least 3 hierarchy
  levels, with links to other drafts under the same workflow or in other workflows, pointing at either terminal or 
- non-terminal pages, either workflow root pages or child pages
+ non-terminal pages, either workflow root pages or child pages, in the same wiki or in a distinct wiki.
 * Initialize workflow on that page and check the "include children" option
 * Submit page to moderation, then to validation
 * Publish page

--- a/tests.md
+++ b/tests.md
@@ -1,0 +1,70 @@
+# Publication Workflow Tests
+
+## Test setup
+
+* Create a workflow configuration with the "hide drafts" option activated
+
+## Terminal page
+
+### Scenario
+
+* Create page in multiple languages with links to other drafts
+* Initialize workflow on that page
+* Submit page to moderation, then to validation
+* Publish page
+* Remove some translations from draft, then republish
+* Add rights to the published page, then republish
+* Archive page
+
+### Expected results
+
+* The draft page is marked as hidden
+* Page rights are updated on each transition along the chosen workflow configuration groups
+* The publish action creates a page at the expected location, with translations
+* The published page links referring to pages under workflow point at published pages, not at draft ones, in the default
+ page as well as in the translations, even if the drafts are not published yet
+* On second publication, the rights set on the published page are not overriden
+* When a translation gets removed from the draft, the corresponding published translation gets removed on next publish
+* On page archiving, the page and all its translations become hidden
+
+## Page with children, workflow with children
+
+### Scenario
+
+* Create page in multiple languages containing both non-terminal and terminal children, with at least 3 hierarchy
+ levels, with links to other drafts under the same workflow or in other workflows, pointing at either terminal or non
+-terminal pages, either workflow root pages or child pages.
+* Initialize workflow on that page and check the "include children" option
+* Submit page to moderation, then to validation
+* Publish page
+* Remove some children from draft, then republish
+* Add rights to the published page hierarchy, then republish
+* Archive page
+* Publish page from archive
+
+### Expected results
+
+* Page draft and its children are marked as hidden
+* Page hierarchical rights (WebPreferences) are updated on each transition along the chosen workflow configuration
+ groups
+* The publish action creates a page at the expected location with its children published as well and its grandchildren
+* Links in the published pages pointing at pages which are under workflow point exclusively at published pages, not
+ draft ones, even if the drafts are not published yet.
+* When draft page children or grandchildren get removed, the corresponding published children or grandchildren get
+ removed on next publish
+* When rights are updated on the published page hierarchy, they are preserved on next publish
+* On page archiving, the main page, the children and grandchildren get hidden
+* On page publication from archive, the main page, its children and grandchildren get unhidden 
+
+## Page with children, workflow without children
+
+### Scenario
+
+* Create page with children
+* Initialize workflow without checking the "include children" option
+* Moderate and publish page
+
+### Expected results
+
+* Local rights are used on the draft page, not hierarchical ones
+* The page gets published, but not its children

--- a/tests.md
+++ b/tests.md
@@ -41,6 +41,7 @@
 * Add rights to the published page hierarchy, then republish
 * Archive page
 * Publish page from archive
+* Create new child in draft, with a workflow configuration where drafts are marked as hidden
 
 ### Expected results
 
@@ -55,7 +56,9 @@
  removed on next publish
 * When rights are updated on the published page hierarchy, they are preserved on next publish
 * On page archiving, the main page, the children and grandchildren get hidden
-* On page publication from archive, the main page, its children and grandchildren get unhidden 
+* On page publication from archive, the main page, its children and grandchildren get unhidden
+* Newly created child pages in draft document after the workflow has been initialized are marked as hidden if the
+ corresponding workflow config says so (not implemented) 
 
 ## Page with children, workflow without children
 

--- a/xwiki-workflow-publication-api/pom.xml
+++ b/xwiki-workflow-publication-api/pom.xml
@@ -33,6 +33,11 @@
   <dependencies>
     <dependency>
       <groupId>org.xwiki.contrib.api-rights</groupId>
+      <artifactId>api-rights-api</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.contrib.api-rights</groupId>
       <artifactId>api-rights-bridge</artifactId>
       <version>1.1</version>
     </dependency>

--- a/xwiki-workflow-publication-api/pom.xml
+++ b/xwiki-workflow-publication-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
 <!--
- *
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
  *
@@ -18,24 +18,28 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- *
 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.contrib.workflow-publication</groupId>
     <artifactId>xwiki-workflow-publication</artifactId>
-    <version>1.11-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
   <artifactId>xwiki-workflow-publication-api</artifactId>
   <name>XWiki Workflow Publication API</name>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-oldcore</artifactId>
-      <version>${xwiki.platform.version}</version>
-      <scope>provided</scope>
+      <groupId>org.xwiki.contrib.api-rights</groupId>
+      <artifactId>api-rights-bridge</artifactId>
+      <version>1.1</version>
     </dependency>
   </dependencies>
+  <properties>
+    <xwiki.revapi.skip>true</xwiki.revapi.skip>
+    <xwiki.checkstyle.skip>true</xwiki.checkstyle.skip>
+    <xwiki.spoon.skip>true</xwiki.spoon.skip>
+  </properties>
 </project>

--- a/xwiki-workflow-publication-api/pom.xml
+++ b/xwiki-workflow-publication-api/pom.xml
@@ -32,6 +32,12 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-oldcore</artifactId>
+      <version>12.10.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.contrib.api-rights</groupId>
       <artifactId>api-rights-api</artifactId>
       <version>1.1</version>

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/DocumentChildPublishingEvent.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/DocumentChildPublishingEvent.java
@@ -1,0 +1,78 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.workflowpublication;
+
+import org.xwiki.bridge.event.AbstractDocumentEvent;
+import org.xwiki.model.reference.DocumentReference;
+/**
+ * Sent before a document that is a descendant of a workflow document gets published through the publication
+ * workflow. Distinct from {@link DocumentPublishingEvent} in order to distinguish between the publication of the
+ * document holding the workflow object and the publication of the descendants.
+ *
+ * @version $Id$
+ */
+
+public class DocumentChildPublishingEvent extends AbstractDocumentEvent
+{
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * A reference to the page getting published.
+     */
+    private DocumentReference childReference;
+
+    /**
+     * A reference to the workflow document in the context of which the publication occurs.
+     */
+    private DocumentReference workflowDocumentReference;
+
+    /**
+     * Default constructor.
+     */
+    public DocumentChildPublishingEvent()
+    {
+        super();
+    }
+
+    /**
+     * Creates a {@link DocumentChildPublishingEvent}
+     * @param childReference a reference to the descendant getting published
+     * @param workflowDocumentReference a reference to the workflow in the context of which the event occurs
+     */
+    public DocumentChildPublishingEvent(DocumentReference childReference, DocumentReference workflowDocumentReference)
+    {
+        this.childReference = childReference;
+        this.workflowDocumentReference = workflowDocumentReference;
+    }
+
+    /**
+     * @return a reference to the descendant getting published
+     */
+    public DocumentReference getDocumentChildReference() {
+        return childReference;
+    }
+
+    /**
+     * @return a reference to the workflow in the context of which the event occurs
+     */
+    public DocumentReference getWorkflowDocumentReference() {
+        return workflowDocumentReference;
+    }
+}

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/DocumentChildPublishingEvent.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/DocumentChildPublishingEvent.java
@@ -22,9 +22,11 @@ package org.xwiki.workflowpublication;
 import org.xwiki.bridge.event.AbstractDocumentEvent;
 import org.xwiki.model.reference.DocumentReference;
 /**
- * Sent before a document that is a descendant of a workflow document gets published through the publication
- * workflow. Distinct from {@link DocumentPublishingEvent} in order to distinguish between the publication of the
- * document holding the workflow object and the publication of the descendants.
+ * This event is sent before a descendant of a workflow document gets published through the publication workflow.
+ * It is distinct from {@link DocumentPublishingEvent} in order to distinguish between the publication of the document
+ * holding the workflow object and the publication of its descendants: the former is the main event that external
+ * applications may listen to, while the latter is used internally by the publication workflow to perform
+ * operations on the descendants before publishing, such as updating the references.
  *
  * @version $Id$
  */

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
@@ -243,7 +243,8 @@ public interface PublicationWorkflow
 
     /**
      * Returns a reference to the first document containing a workflow object in the given reference's ancestors
-     * including the passed reference itself, from the passed reference to the root.
+     * including the passed reference itself, from the passed reference to the root, and whose hierarchical scope
+     * ("includeChildren" option) includes the passed document in case the workflow document is an ancestor.
      * @param reference a {@link DocumentReference}
      * @return a reference to the ancestor workflow owning the passed reference if any, null otherwise
      * @throws XWikiException

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
@@ -243,7 +243,7 @@ public interface PublicationWorkflow
 
     /**
      * Returns a reference to the first document containing a workflow object in the given reference's ancestors
-     * including the passed reference itself.
+     * including the passed reference itself, from the passed reference to the root.
      * @param reference a {@link DocumentReference}
      * @return a reference to the ancestor workflow owning the passed reference if any, null otherwise
      * @throws XWikiException

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
@@ -23,6 +23,7 @@ import org.xwiki.component.annotation.Role;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -59,6 +60,7 @@ public interface PublicationWorkflow
     public boolean startWorkflow(DocumentReference doc, String workflowConfig, DocumentReference target,
         XWikiContext xcontext) throws XWikiException;
 
+    @Unstable
     public boolean startWorkflow(DocumentReference doc, boolean includeChildren, String workflowConfig,
         DocumentReference target, XWikiContext xcontext) throws XWikiException;
 
@@ -249,6 +251,7 @@ public interface PublicationWorkflow
      * @return a reference to the ancestor workflow owning the passed reference if any, null otherwise
      * @throws XWikiException
      */
+    @Unstable
     DocumentReference getWorkflowDocument(DocumentReference reference) throws XWikiException;
 
     /**
@@ -259,6 +262,7 @@ public interface PublicationWorkflow
      * @param workflowDocumentTarget the target of the workflow document owning the given descendant
      * @return the descendant's target reference
      */
+    @Unstable
     DocumentReference getChildTarget(DocumentReference descendant, DocumentReference workflowDocumentDraft,
         DocumentReference workflowDocumentTarget);
 }

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
@@ -255,9 +255,10 @@ public interface PublicationWorkflow
      * Computes the target of a workflow document descendant, based on the workflow document target. For instance, if
      * the workflow document is "Drafts.ABC.WebHome", with a target "Published.ABC.WebHome", the target of the
      * descendant document "Drafts.ABC.DEF.WebHome" is "Published.ABC.DEF.WebHome".
-     * @param reference a reference to a descendant of a workflow document
+     * @param descendant a reference to a descendant of a workflow document
      * @param workflowDocumentTarget the target of the workflow document owning the given descendant
      * @return the descendant's target reference
      */
-    DocumentReference getChildTarget(DocumentReference reference, DocumentReference workflowDocumentTarget);
+    DocumentReference getChildTarget(DocumentReference descendant, DocumentReference workflowDocumentDraft,
+        DocumentReference workflowDocumentTarget);
 }

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
@@ -59,6 +59,9 @@ public interface PublicationWorkflow
     public boolean startWorkflow(DocumentReference doc, String workflowConfig, DocumentReference target,
         XWikiContext xcontext) throws XWikiException;
 
+    public boolean startWorkflow(DocumentReference doc, boolean includeChildren, String workflowConfig,
+        DocumentReference target, XWikiContext xcontext) throws XWikiException;
+
     /**
      * Starts the workflow on {@code target} as the published document, without creating the draft document. The draft
      * can be created the first time when the function {@link #createDraftDocument(DocumentReference, XWikiContext)}
@@ -237,4 +240,23 @@ public interface PublicationWorkflow
      * @throws XWikiException
      */
     public boolean publishFromArchive(DocumentReference document) throws XWikiException;
+
+    /**
+     * Returns a reference to the first document containing a workflow object in the given reference's ancestors
+     * including the passed reference itself.
+     * @param reference a {@link DocumentReference}
+     * @return a reference to the ancestor workflow owning the passed reference if any, null otherwise
+     * @throws XWikiException
+     */
+    DocumentReference getWorkflowDocument(DocumentReference reference) throws XWikiException;
+
+    /**
+     * Computes the target of a workflow document descendant, based on the workflow document target. For instance, if
+     * the workflow document is "Drafts.ABC.WebHome", with a target "Published.ABC.WebHome", the target of the
+     * descendant document "Drafts.ABC.DEF.WebHome" is "Published.ABC.DEF.WebHome".
+     * @param reference a reference to a descendant of a workflow document
+     * @param workflowDocumentTarget the target of the workflow document owning the given descendant
+     * @return the descendant's target reference
+     */
+    DocumentReference getChildTarget(DocumentReference reference, DocumentReference workflowDocumentTarget);
 }

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultPublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultPublicationWorkflow.java
@@ -1279,11 +1279,11 @@ public class DefaultPublicationWorkflow implements PublicationWorkflow
     }
 
     /**
-     * Copies/merges a draft page to a target in all draft page locales. Also copies recursively the draft's children if
-     * {@code includeChildren} is <code>true</code>. The draft locales and children get removed from the target if
-     * they do not exist in the draft. In case the page to be copied is a workflow document (i.e. a document
+     * Copies/merges a source page to a target in all source page locales. Also copies recursively the source
+     * children if {@code includeChildren} is <code>true</code>. The source locales and children get removed from the
+     * target if they do not exist in the source. In case the page to be copied is a workflow document (i.e. a document
      * holding a <code>PublicationWorkflowClass</code> object), sets up a workflow object in the target. Fires a
-     * {@link DocumentChildPublishingEvent} when copying draft pages which are not holding a workflow object.
+     * {@link DocumentChildPublishingEvent} when copying source pages which are not holding a workflow object.
      * @param source a reference to a document to be copied/merged
      * @param target a reference to the document to be created or updated
      * @param workflowDocumentReference a reference to the workflow document holding the workflow object in the

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultPublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultPublicationWorkflow.java
@@ -1374,7 +1374,7 @@ public class DefaultPublicationWorkflow implements PublicationWorkflow
             // anymore so as to delete them.
             List<DocumentReference> obsoletePublishedChildren = getChildren(target);
             for (DocumentReference child : children) {
-                DocumentReference childTarget = getChildTarget(child, target);
+                DocumentReference childTarget = getChildTarget(child, draft, target);
                 copyDocument(child, childTarget, workflowDocumentReference, publisher,true);
                 obsoletePublishedChildren.remove(childTarget);
             }
@@ -1408,15 +1408,10 @@ public class DefaultPublicationWorkflow implements PublicationWorkflow
     }
 
     @Override
-    public DocumentReference getChildTarget(DocumentReference child, DocumentReference workflowDocumentTarget)
+    public DocumentReference getChildTarget(DocumentReference child, DocumentReference workflowDocumentDraft,
+        DocumentReference workflowDocumentTarget)
     {
-        if (isTerminal(child)) {
-            return new DocumentReference(child.getName(), workflowDocumentTarget.getLastSpaceReference());
-        } else {
-            SpaceReference spaceReference =
-                new SpaceReference(child.getLastSpaceReference(), workflowDocumentTarget.getLastSpaceReference());
-            return child.replaceParent(child.getLastSpaceReference(), spaceReference);
-        }
+        return child.replaceParent(workflowDocumentDraft.getParent(), workflowDocumentTarget.getParent());
     }
 
     @Override

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultPublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultPublicationWorkflow.java
@@ -1430,7 +1430,12 @@ public class DefaultPublicationWorkflow implements PublicationWorkflow
                 XWikiDocument ancestorDocument = context.getWiki().getDocument(ancestor, context);
                 BaseObject workflow = ancestorDocument.getXObject(PUBLICATION_WORKFLOW_CLASS);
                 if (workflow != null) {
-                    return ancestorDocument.getDocumentReference();
+                    // Return ancestor reference either if it is the passed document reference itself
+                    // or if it is a real ancestor with a workflow whose scope includes the descendants.
+                    int includeChildren = workflow.getIntValue(WF_INCLUDE_CHILDREN_FIELDNAME);
+                    if (ancestorDocument.getDocumentReference().equals(document) || includeChildren == 1) {
+                        return ancestorDocument.getDocumentReference();
+                    }
                 }
             }
         }

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
@@ -1,3 +1,22 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.xwiki.workflowpublication.internal;
 
 import java.util.ArrayList;
@@ -626,8 +645,7 @@ public class PublicationWorkflowRenameListener implements EventListener
             context.put(EQUIVALENT_DOCUMENT_MOVE_KEY, true);
             logger.info("Moving equivalent document [{}] to destination [{}]", oldEquivalentDocumentReference,
                 newEquivalentDocumentReference);
-            xwiki.renamePage(stringSerializer.serialize(oldEquivalentDocumentReference),
-                stringSerializer.serialize(newEquivalentDocumentReference),
+            xwiki.renameDocument(oldEquivalentDocumentReference, newEquivalentDocumentReference, true, null, null,
                 context);
             context.remove(EQUIVALENT_DOCUMENT_MOVE_KEY);
         } catch (Exception e) {

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
@@ -118,10 +118,16 @@ public class PublicationWorkflowService implements ScriptService
 
     public boolean startWorkflow(DocumentReference doc, String workflowConfig, DocumentReference target)
     {
+        return this.startWorkflow(doc, false, workflowConfig, target);
+    }
+
+    public boolean startWorkflow(DocumentReference doc, boolean includeChildren, String workflowConfig,
+        DocumentReference target)
+    {
         XWikiContext xcontext = getXContext();
         try {
             if (authManager.hasAccess(Right.EDIT, xcontext.getUserReference(), doc)) {
-                return this.publicationWorkflow.startWorkflow(doc, workflowConfig, target, xcontext);
+                return this.publicationWorkflow.startWorkflow(doc, includeChildren, workflowConfig, target, xcontext);
             } else {
                 // TODO: put error on context
                 return false;
@@ -379,6 +385,17 @@ public class PublicationWorkflowService implements ScriptService
             // TODO: put error on context
             return false;
         }
+    }
+
+    /**
+     * See {@link PublicationWorkflow#getChildTarget(DocumentReference, DocumentReference)}
+     * @param reference a reference to a workflow document child
+     * @param workflowTarget the target of the workflow document owning the given child
+     * @return a reference to the child target
+     */
+    public DocumentReference getChildTarget(DocumentReference reference, DocumentReference workflowTarget)
+    {
+        return this.publicationWorkflow.getChildTarget(reference, workflowTarget);
     }
 
     /**

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
@@ -388,14 +388,15 @@ public class PublicationWorkflowService implements ScriptService
     }
 
     /**
-     * See {@link PublicationWorkflow#getChildTarget(DocumentReference, DocumentReference)}
+     * See {@link PublicationWorkflow#getChildTarget(DocumentReference, DocumentReference, DocumentReference)}
      * @param reference a reference to a workflow document child
      * @param workflowTarget the target of the workflow document owning the given child
      * @return a reference to the child target
      */
-    public DocumentReference getChildTarget(DocumentReference reference, DocumentReference workflowTarget)
+    public DocumentReference getChildTarget(DocumentReference reference, DocumentReference workflowDraft,
+        DocumentReference workflowTarget)
     {
-        return this.publicationWorkflow.getChildTarget(reference, workflowTarget);
+        return this.publicationWorkflow.getChildTarget(reference, workflowDraft, workflowTarget);
     }
 
     /**

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/ReferencesTransformDocPublishingEventListener.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/ReferencesTransformDocPublishingEventListener.java
@@ -225,14 +225,15 @@ public class ReferencesTransformDocPublishingEventListener implements EventListe
     }
 
     /**
-     * check if the given reference is a draft document in a workflow, and if so, return a reference to its target
-     * document, null otherwise.
+     * Checks if a given reference is a draft document in a workflow (either main workflow document or a descendant),
+     * and if so, returns a reference to its target document, null otherwise.
      *
-     * @param reference the document
-     * @return null if not in workflow, or the reference to the target document
+     * @param reference a {@link DocumentReference}
+     * @return a reference to the target document if the passed reference is in a workflow, null otherwise
      */
     private String getTargetDocRefInWorkflow(DocumentReference reference, XWikiContext context) throws XWikiException
     {
+        // Compute the parent workflow the given reference belongs to, if any
         DocumentReference linkedWorkflowDocumentRefence = publicationWorkflow.getWorkflowDocument(reference);
         if (linkedWorkflowDocumentRefence == null) {
             return null;

--- a/xwiki-workflow-publication-application/pom.xml
+++ b/xwiki-workflow-publication-application/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
 <!--
- *
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
  *
@@ -18,18 +18,26 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- *
 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.contrib.workflow-publication</groupId>
     <artifactId>xwiki-workflow-publication</artifactId>
-    <version>1.11-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
   <artifactId>xwiki-workflow-publication-application</artifactId>
   <name>XWiki Publication Workflow Application</name>
   <packaging>xar</packaging>
+  <properties>
+    <xwiki.extension.name>Publication Workflow Application</xwiki.extension.name>
+    <xwiki.extension.category>application</xwiki.extension.category>
+    <xwiki.release.jira.skip>true</xwiki.release.jira.skip>
+    <xwiki.issueManagement.system>jira</xwiki.issueManagement.system>
+    <xwiki.issueManagement.url>https://jira.xwiki.org/projects/XAWORKFLOW/</xwiki.issueManagement.url>
+    <platform.version>12.10.4</platform.version>
+  </properties>
   <dependencies>
     <!-- Adding publication workflow api as dependencies since these pages need the 
       server in order to work properly and for EM to find them related. -->
@@ -40,18 +48,15 @@
     </dependency>
   </dependencies>
   <build>
-    <extensions>
-      <extension>
-        <groupId>org.xwiki.commons</groupId>
-        <artifactId>xwiki-commons-tool-xar-handlers</artifactId>
-      </extension>
-    </extensions>
     <plugins>
       <plugin>
         <groupId>org.xwiki.commons</groupId>
         <artifactId>xwiki-commons-tool-xar-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <visibleTechnicalPages>
+            <visibleTechnicalPage>.*/PublicationWorkflow/Overview\.xml</visibleTechnicalPage>
+            <visibleTechnicalPage>.*/PublicationWorkflow/WebHome\.xml</visibleTechnicalPage>
+          </visibleTechnicalPages>
         </configuration>
       </plugin>
     </plugins>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/ApplicationsPanelEntry.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/ApplicationsPanelEntry.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,19 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.ApplicationsPanelEntry" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.ApplicationsPanelEntry" locale="">
   <web>PublicationWorkflow</web>
   <name>ApplicationsPanelEntry</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1346774793000</creationDate>
   <parent>Blog.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1524953210000</date>
-  <contentUpdateDate>1458059553000</contentUpdateDate>
   <version>1.1</version>
   <title>Applications Panel Entry</title>
   <comment/>
@@ -54,20 +51,61 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>3</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>4</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>2</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
       <content>
         <disabled>0</disabled>
+        <editor>Text</editor>
         <name>content</name>
-        <number>3</number>
-        <prettyName>Extension Content</prettyName>
-        <rows>10</rows>
-        <size>40</size>
+        <number>1</number>
+        <prettyName>Executed Content</prettyName>
+        <rows>25</rows>
+        <size>120</size>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </content>
       <extensionPointId>
         <disabled>0</disabled>
         <name>extensionPointId</name>
-        <number>1</number>
+        <number>5</number>
         <prettyName>Extension Point ID</prettyName>
         <size>30</size>
         <unmodifiable>0</unmodifiable>
@@ -76,16 +114,18 @@
       <name>
         <disabled>0</disabled>
         <name>name</name>
-        <number>2</number>
+        <number>6</number>
         <prettyName>Extension ID</prettyName>
         <size>30</size>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
       <parameters>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>parameters</name>
-        <number>4</number>
+        <number>7</number>
         <prettyName>Extension Parameters</prettyName>
         <rows>10</rows>
         <size>40</size>
@@ -96,9 +136,11 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>scope</name>
-        <number>5</number>
+        <number>8</number>
         <prettyName>Extension Scope</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -109,6 +151,15 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </scope>
     </class>
+    <property>
+      <async_cached/>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled/>
+    </property>
     <property>
       <content/>
     </property>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/DepublicationMailTemplate.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/DepublicationMailTemplate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,18 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc version="1.4" reference="PublicationWorkflow.DepublicationMailTemplate" locale="">
   <web>PublicationWorkflow</web>
   <name>DepublicationMailTemplate</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1358181201000</creationDate>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1434368237000</date>
-  <contentUpdateDate>1434368237000</contentUpdateDate>
   <version>1.1</version>
   <title>DepublicationMailTemplate</title>
   <comment/>
@@ -54,7 +52,9 @@
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -82,7 +82,9 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -124,7 +126,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -152,7 +156,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Overview.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Overview.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,19 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.Overview" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.Overview" locale="">
   <web>PublicationWorkflow</web>
   <name>Overview</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357902263000</creationDate>
   <parent>PublicationWorkflow.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1358879531000</date>
-  <contentUpdateDate>1358879531000</contentUpdateDate>
   <version>1.1</version>
   <title>$services.localization.render('workflow.overview.title')</title>
   <comment/>
@@ -156,8 +153,11 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
         <number>5</number>
@@ -171,7 +171,9 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </cache>
       <code>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
@@ -203,6 +205,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
         <number>3</number>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationRefusalMailTemplate.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationRefusalMailTemplate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,29 +20,28 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc>
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationRefusalMailTemplate" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationRefusalMailTemplate</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent/>
   <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
-  <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1358181005000</creationDate>
-  <date>1433937329000</date>
-  <contentUpdateDate>1433856579000</contentUpdateDate>
   <version>1.1</version>
   <title>PublicationRefusalMailTemplate</title>
-  <defaultTemplate/>
-  <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
+  <content>Modèle de mail à envoyer aux modérateurs lorsque les Webmasters ont refusé la publication d'un document qu'ils avaient validé. </content>
   <object>
+    <name>PublicationWorkflow.PublicationRefusalMailTemplate</name>
+    <number>0</number>
+    <className>XWiki.Mail</className>
+    <guid>25f1835d-7290-49ea-bd63-a5c5d8d29dff</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -53,7 +52,9 @@
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -81,7 +82,9 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -91,10 +94,6 @@
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.PublicationRefusalMailTemplate</name>
-    <number>0</number>
-    <className>XWiki.Mail</className>
-    <guid>25f1835d-7290-49ea-bd63-a5c5d8d29dff</guid>
     <property>
       <html>Les webmasters ont refusé de valider le document $document pour les raisons suivantes : $reason &lt;br&gt;
 Vous pouvez revenir au brouillon pour le modifier &lt;a href="$url"&gt;ici&lt;/a&gt;. 
@@ -115,6 +114,10 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
     </property>
   </object>
   <object>
+    <name>PublicationWorkflow.PublicationRefusalMailTemplate</name>
+    <number>1</number>
+    <className>XWiki.Mail</className>
+    <guid>a0290ed7-24ce-4eb5-abbb-89b4cfd0859c</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -125,7 +128,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -153,7 +158,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -163,10 +170,6 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.PublicationRefusalMailTemplate</name>
-    <number>1</number>
-    <className>XWiki.Mail</className>
-    <guid>a0290ed7-24ce-4eb5-abbb-89b4cfd0859c</guid>
     <property>
       <html>The webmasters have refused to validate the document $document for the following reasons : $reason &lt;br&gt;
 In order to modify it, you can access the draft by clicking this &lt;a href="$url"&gt;link&lt;/a&gt;.
@@ -186,5 +189,4 @@ In order to modify it, you can access the draft by clicking this link : $url.
 This message has been automatically sent by XWiki.</text>
     </property>
   </object>
-  <content>Modèle de mail à envoyer aux modérateurs lorsque les Webmasters ont refusé la publication d'un document qu'ils avaient validé. </content>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationRequestMailTemplate.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationRequestMailTemplate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,29 +20,28 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc>
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationRequestMailTemplate" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationRequestMailTemplate</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent/>
   <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
-  <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1358173900000</creationDate>
-  <date>1433937118000</date>
-  <contentUpdateDate>1433856577000</contentUpdateDate>
   <version>1.1</version>
   <title/>
-  <defaultTemplate/>
-  <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
+  <content/>
   <object>
+    <name>PublicationWorkflow.PublicationRequestMailTemplate</name>
+    <number>0</number>
+    <className>XWiki.Mail</className>
+    <guid>ebbe64a5-cb8a-4f30-805b-87c40ef67ddd</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -53,7 +52,9 @@
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -81,7 +82,9 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -91,10 +94,6 @@
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.PublicationRequestMailTemplate</name>
-    <number>0</number>
-    <className>XWiki.Mail</className>
-    <guid>ebbe64a5-cb8a-4f30-805b-87c40ef67ddd</guid>
     <property>
       <html>Le document $document a été validé par les modérateurs. Vous pouvez consulter sa version actuelle &lt;a href=$url&gt; ici &lt;/a&gt;, et choisir de le publier ou non. &lt;br&gt;&lt;br&gt; 
 
@@ -113,6 +112,10 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
     </property>
   </object>
   <object>
+    <name>PublicationWorkflow.PublicationRequestMailTemplate</name>
+    <number>1</number>
+    <className>XWiki.Mail</className>
+    <guid>5c442f5a-ca5d-4de4-aa5d-6b3742637c04</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -123,7 +126,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -151,7 +156,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -161,10 +168,6 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.PublicationRequestMailTemplate</name>
-    <number>1</number>
-    <className>XWiki.Mail</className>
-    <guid>5c442f5a-ca5d-4de4-aa5d-6b3742637c04</guid>
     <property>
       <html>The document $document has been validated by the moderators. You can access the current version &lt;a href=$url&gt;here&lt;/a&gt; and choose whether to publish it or not. &lt;br&gt;&lt;br&gt; 
 
@@ -182,5 +185,4 @@ This message has been automatically sent by XWiki.</html>
 This message has been automatically sent by XWiki.</text>
     </property>
   </object>
-  <content/>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowClass.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowClass.xml
@@ -52,14 +52,30 @@
     <defaultWeb/>
     <nameField/>
     <validationScript/>
+    <includeChildren>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayFormType>checkbox</displayFormType>
+      <displayType/>
+      <hint/>
+      <name>includeChildren</name>
+      <number>3</number>
+      <prettyName>includeChildren</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </includeChildren>
     <istarget>
       <customDisplay/>
       <defaultValue>0</defaultValue>
       <disabled>0</disabled>
       <displayFormType>checkbox</displayFormType>
       <displayType/>
+      <hint/>
       <name>istarget</name>
-      <number>4</number>
+      <number>5</number>
       <prettyName>istarget</prettyName>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -69,8 +85,12 @@
     <status>
       <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
       <displayType>select</displayType>
+      <freeText/>
+      <hint/>
+      <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>status</name>
       <number>1</number>
@@ -90,11 +110,15 @@
     <statusAuthor>
       <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
+      <freeText/>
+      <hint/>
+      <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>statusAuthor</name>
-      <number>5</number>
+      <number>6</number>
       <picker>1</picker>
       <prettyName>statusAuthor</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -111,8 +135,9 @@
     <target>
       <customDisplay/>
       <disabled>0</disabled>
+      <hint/>
       <name>target</name>
-      <number>3</number>
+      <number>4</number>
       <picker>0</picker>
       <prettyName>target</prettyName>
       <size>30</size>
@@ -125,9 +150,13 @@
       <cache>0</cache>
       <classname/>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
       <displayType>select</displayType>
+      <freeText/>
+      <hint/>
       <idField/>
+      <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>workflow</name>
       <number>2</number>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowClass.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowClass.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,29 +20,29 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc>
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowClass" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowClass</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent>XWiki.XWikiClasses</parent>
   <creator>xwiki:XWiki.Admin</creator>
+  <parent>XWiki.XWikiClasses</parent>
   <author>xwiki:XWiki.Admin</author>
-  <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1357556434000</creationDate>
-  <date>1359127677000</date>
-  <contentUpdateDate>1359127677000</contentUpdateDate>
   <version>1.1</version>
   <title>PublicationWorkflow Class</title>
-  <template/>
-  <defaultTemplate/>
-  <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.0</syntaxId>
   <hidden>true</hidden>
+  <content>{{velocity}}
+## Replace Main with the Space where you want your documents to be created.
+## Replace the default parent with the one of your choice and save the document.
+##
+#set($defaultParent = $doc.fullName)
+#set($defaultSpace = 'Main')
+{{/velocity}}</content>
   <class>
     <name>PublicationWorkflow.PublicationWorkflowClass</name>
     <customClass/>
@@ -147,6 +147,10 @@
     </workflow>
   </class>
   <object>
+    <name>PublicationWorkflow.PublicationWorkflowClass</name>
+    <number>0</number>
+    <className>XWiki.DocumentSheetBinding</className>
+    <guid>e8594265-b834-4d3e-b07c-31b427b556eb</guid>
     <class>
       <name>XWiki.DocumentSheetBinding</name>
       <customClass/>
@@ -157,32 +161,33 @@
       <nameField/>
       <validationScript/>
       <sheet>
+        <cache>0</cache>
+        <classname/>
         <customDisplay/>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <hint/>
+        <idField/>
+        <multiSelect>0</multiSelect>
         <name>sheet</name>
         <number>1</number>
-        <picker>0</picker>
+        <picker>1</picker>
         <prettyName>Sheet</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
         <size>30</size>
+        <sort>none</sort>
+        <sql/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </sheet>
     </class>
-    <name>PublicationWorkflow.PublicationWorkflowClass</name>
-    <number>0</number>
-    <className>XWiki.DocumentSheetBinding</className>
-    <guid>e8594265-b834-4d3e-b07c-31b427b556eb</guid>
     <property>
       <sheet>XWiki.ClassSheet</sheet>
     </property>
   </object>
-  <content>{{velocity}}
-## Replace Main with the Space where you want your documents to be created.
-## Replace the default parent with the one of your choice and save the document.
-##
-#set($defaultParent = $doc.fullName)
-#set($defaultSpace = 'Main')
-{{/velocity}}</content>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigClass.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigClass.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,19 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.PublicationWorkflowConfigClass" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowConfigClass" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowConfigClass</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357556743000</creationDate>
   <parent>XWiki.XWikiClasses</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1361371411000</date>
-  <contentUpdateDate>1361371411000</contentUpdateDate>
   <version>1.1</version>
   <title>PublicationWorkflowConfig Class</title>
   <comment/>
@@ -257,17 +254,29 @@
       <nameField/>
       <validationScript/>
       <sheet>
+        <cache>0</cache>
+        <classname/>
         <customDisplay/>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <hint/>
+        <idField/>
+        <multiSelect>0</multiSelect>
         <name>sheet</name>
         <number>1</number>
-        <picker>0</picker>
+        <picker>1</picker>
         <prettyName>Sheet</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
         <size>30</size>
+        <sort>none</sort>
+        <sql/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </sheet>
     </class>
     <property>
@@ -289,17 +298,29 @@
       <nameField/>
       <validationScript/>
       <sheet>
+        <cache>0</cache>
+        <classname/>
         <customDisplay/>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <hint/>
+        <idField/>
+        <multiSelect>0</multiSelect>
         <name>sheet</name>
         <number>1</number>
-        <picker>0</picker>
+        <picker>1</picker>
         <prettyName>Sheet</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
         <size>30</size>
+        <sort>none</sort>
+        <sql/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </sheet>
     </class>
     <property>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigGroupsDisplay.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigGroupsDisplay.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,18 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowConfigGroupsDisplay" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowConfigGroupsDisplay</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1361370502000</creationDate>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1361371552000</date>
-  <contentUpdateDate>1361371552000</contentUpdateDate>
   <version>1.1</version>
   <title>PublicationWorkflowConfigGroupsDisplay</title>
   <comment/>
@@ -66,22 +64,27 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
         <number>5</number>
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>long|short|default|forbid</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </cache>
       <code>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
@@ -113,13 +116,15 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
         <number>3</number>
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>currentPage|onDemand|always</values>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigSheet.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigSheet.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,19 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.PublicationWorkflowConfigSheet" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowConfigSheet" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowConfigSheet</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357556835000</creationDate>
   <parent>PublicationWorkflow.PublicationWorkflowConfigClass</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1358262508000</date>
-  <contentUpdateDate>1358262508000</contentUpdateDate>
   <version>1.1</version>
   <title>#if($doc.documentReference.name == 'PublicationWorkflowConfigSheet')PublicationWorkflowConfig Sheet#{else}$services.display.title($doc, {'displayerHint': 'default'})#end</title>
   <comment/>
@@ -72,11 +69,14 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
-        <number>6</number>
+        <number>5</number>
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -87,9 +87,11 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </cache>
       <code>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>code</name>
-        <number>3</number>
+        <number>2</number>
         <prettyName>Code</prettyName>
         <rows>20</rows>
         <size>50</size>
@@ -100,9 +102,11 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
-        <number>1</number>
+        <number>6</number>
         <prettyName>Content Type</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -115,7 +119,7 @@
       <name>
         <disabled>0</disabled>
         <name>name</name>
-        <number>2</number>
+        <number>1</number>
         <prettyName>Name</prettyName>
         <size>30</size>
         <unmodifiable>0</unmodifiable>
@@ -126,7 +130,7 @@
         <displayFormType>select</displayFormType>
         <displayType>yesno</displayType>
         <name>parse</name>
-        <number>5</number>
+        <number>4</number>
         <prettyName>Parse content</prettyName>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
@@ -135,9 +139,11 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
-        <number>4</number>
+        <number>3</number>
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigTemplate.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigTemplate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,30 +20,28 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc>
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowConfigTemplate" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowConfigTemplate</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent>PublicationWorkflow.PublicationWorkflowConfigClass</parent>
   <creator>xwiki:XWiki.Admin</creator>
+  <parent>PublicationWorkflow.PublicationWorkflowConfigClass</parent>
   <author>xwiki:XWiki.Admin</author>
-  <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1357556833000</creationDate>
-  <date>1358262522000</date>
-  <contentUpdateDate>1358262522000</contentUpdateDate>
   <version>1.1</version>
   <title>PublicationWorkflowConfig Template</title>
-  <template/>
-  <defaultTemplate/>
-  <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
+  <content/>
   <object>
+    <name>PublicationWorkflow.PublicationWorkflowConfigTemplate</name>
+    <number>0</number>
+    <className>PublicationWorkflow.PublicationWorkflowConfigClass</className>
+    <guid>9b9c5b6f-15d5-4de6-a649-0d01841d0c04</guid>
     <class>
       <name>PublicationWorkflow.PublicationWorkflowConfigClass</name>
       <customClass/>
@@ -53,22 +51,48 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <commenter>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay>{{include document="PublicationWorkflow.PublicationWorkflowConfigGroupsDisplay" /}}
+</customDisplay>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <idField/>
+        <multiSelect>0</multiSelect>
+        <name>commenter</name>
+        <number>5</number>
+        <picker>1</picker>
+        <prettyName>commenter</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator/>
+        <separators/>
+        <size>40</size>
+        <sort>none</sort>
+        <sql>select distinct obj.name from XWikiDocument doc, BaseObject obj where doc.fullName = obj.name and obj.className='XWiki.XWikiGroups' and doc.name != 'XWikiGroupTemplate'
+</sql>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+      </commenter>
       <contributor>
         <cache>0</cache>
         <classname/>
-        <customDisplay/>
+        <customDisplay>{{include document="PublicationWorkflow.PublicationWorkflowConfigGroupsDisplay" /}}</customDisplay>
         <disabled>0</disabled>
-        <displayType>select</displayType>
+        <displayType>input</displayType>
         <idField/>
         <multiSelect>0</multiSelect>
         <name>contributor</name>
         <number>1</number>
-        <picker>0</picker>
+        <picker>1</picker>
         <prettyName>contributor</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
         <separators/>
-        <size>1</size>
+        <size>40</size>
         <sort>none</sort>
         <sql>select distinct obj.name from XWikiDocument doc, BaseObject obj where doc.fullName = obj.name and obj.className='XWiki.XWikiGroups' and doc.name != 'XWikiGroupTemplate'</sql>
         <unmodifiable>0</unmodifiable>
@@ -77,22 +101,60 @@
         <valueField/>
         <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
       </contributor>
-      <moderator>
+      <defaultDraftSpace>
         <cache>0</cache>
         <classname/>
         <customDisplay/>
         <disabled>0</disabled>
-        <displayType>select</displayType>
+        <displayType>input</displayType>
+        <idField/>
+        <multiSelect>0</multiSelect>
+        <name>defaultDraftSpace</name>
+        <number>6</number>
+        <picker>1</picker>
+        <prettyName>defaultDraftSpace</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
+        <size>40</size>
+        <sort>none</sort>
+        <sql>select distinct doc.web from XWikiDocument doc</sql>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+      </defaultDraftSpace>
+      <draftsHidden>
+        <customDisplay/>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>radio</displayFormType>
+        <displayType/>
+        <name>draftsHidden</name>
+        <number>7</number>
+        <prettyName>Set Drafts to Hidden?</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </draftsHidden>
+      <moderator>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay>{{include document="PublicationWorkflow.PublicationWorkflowConfigGroupsDisplay" /}}</customDisplay>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
         <idField/>
         <multiSelect>0</multiSelect>
         <name>moderator</name>
         <number>2</number>
-        <picker>0</picker>
+        <picker>1</picker>
         <prettyName>moderator</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
         <separators/>
-        <size>1</size>
+        <size>40</size>
         <sort>none</sort>
         <sql>select distinct obj.name from XWikiDocument doc, BaseObject obj where doc.fullName = obj.name and obj.className='XWiki.XWikiGroups' and doc.name != 'XWikiGroupTemplate'</sql>
         <unmodifiable>0</unmodifiable>
@@ -101,22 +163,46 @@
         <valueField/>
         <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
       </moderator>
+      <moveStrategy>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue>doNothing</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <hint/>
+        <multiSelect>0</multiSelect>
+        <name>moveStrategy</name>
+        <number>8</number>
+        <picker>1</picker>
+        <prettyName>Move strategy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <sort>value</sort>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values>doNothing|moveTargetIfUnpublished|moveTarget|moveDrafts|moveAll</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </moveStrategy>
       <validator>
         <cache>0</cache>
         <classname/>
-        <customDisplay/>
+        <customDisplay>{{include document="PublicationWorkflow.PublicationWorkflowConfigGroupsDisplay" /}}</customDisplay>
         <disabled>0</disabled>
-        <displayType>select</displayType>
+        <displayType>input</displayType>
         <idField/>
         <multiSelect>0</multiSelect>
         <name>validator</name>
         <number>3</number>
-        <picker>0</picker>
+        <picker>1</picker>
         <prettyName>validator</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
         <separators/>
-        <size>1</size>
+        <size>40</size>
         <sort>none</sort>
         <sql>select distinct obj.name from XWikiDocument doc, BaseObject obj where doc.fullName = obj.name and obj.className='XWiki.XWikiGroups' and doc.name != 'XWikiGroupTemplate'</sql>
         <unmodifiable>0</unmodifiable>
@@ -125,20 +211,56 @@
         <valueField/>
         <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
       </validator>
+      <viewer>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay>{{include document="PublicationWorkflow.PublicationWorkflowConfigGroupsDisplay" /}}
+</customDisplay>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <idField/>
+        <multiSelect>0</multiSelect>
+        <name>viewer</name>
+        <number>4</number>
+        <picker>1</picker>
+        <prettyName>viewer</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator/>
+        <separators/>
+        <size>40</size>
+        <sort>none</sort>
+        <sql>select distinct obj.name from XWikiDocument doc, BaseObject obj where doc.fullName = obj.name and obj.className='XWiki.XWikiGroups' and doc.name != 'XWikiGroupTemplate'
+</sql>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+      </viewer>
     </class>
-    <name>PublicationWorkflow.PublicationWorkflowConfigTemplate</name>
-    <number>0</number>
-    <className>PublicationWorkflow.PublicationWorkflowConfigClass</className>
-    <guid>9b9c5b6f-15d5-4de6-a649-0d01841d0c04</guid>
+    <property>
+      <commenter/>
+    </property>
     <property>
       <contributor/>
+    </property>
+    <property>
+      <defaultDraftSpace/>
+    </property>
+    <property>
+      <draftsHidden/>
     </property>
     <property>
       <moderator/>
     </property>
     <property>
+      <moveStrategy/>
+    </property>
+    <property>
       <validator/>
     </property>
+    <property>
+      <viewer/>
+    </property>
   </object>
-  <content/>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigTemplateProvider.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowConfigTemplateProvider.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,18 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.PublicationWorkflowConfigTemplateProvider" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowConfigTemplateProvider" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowConfigTemplateProvider</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357556946000</creationDate>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1358262535000</date>
-  <contentUpdateDate>1358262535000</contentUpdateDate>
   <version>1.1</version>
   <title>PublicationWorkflowConfigTemplateProvider</title>
   <comment/>
@@ -72,7 +70,7 @@
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <values>edit|saveandedit</values>
+        <values>edit|saveandedit|saveandview</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </action>
       <creationRestrictions>
@@ -177,17 +175,29 @@
         <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
       </spaces>
       <template>
+        <cache>0</cache>
+        <classname/>
         <customDisplay/>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <hint/>
+        <idField/>
+        <multiSelect>0</multiSelect>
         <name>template</name>
         <number>2</number>
-        <picker>0</picker>
+        <picker>1</picker>
         <prettyName>template</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
         <size>30</size>
+        <sort>none</sort>
+        <sql/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </template>
       <terminal>
         <customDisplay/>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowLivetableResults.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowLivetableResults.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,25 +20,22 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="PublicationWorkflow.PublicationWorkflowLivetableResults" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowLivetableResults" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowLivetableResults</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1597929565000</creationDate>
   <parent>xwiki:PublicationWorkflow.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1597929567000</date>
-  <contentUpdateDate>1597929565000</contentUpdateDate>
   <version>1.1</version>
   <title>PublicationWorkflowLivetableResults</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
-  <hidden>false</hidden>
+  <hidden>true</hidden>
   <content>{{include reference="XWiki.LiveTableResultsMacros" /}}
 
 {{velocity}}

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
@@ -571,13 +571,13 @@ document.observe('xwiki:dom:loading', function() {
       </visibility>
     </class>
     <property>
-      <async_cached/>
+      <async_cached>0</async_cached>
     </property>
     <property>
       <async_context/>
     </property>
     <property>
-      <async_enabled/>
+      <async_enabled>0</async_enabled>
     </property>
     <property>
       <code>{{velocity}}
@@ -751,6 +751,13 @@ document.observe('xwiki:dom:loading', function() {
                 #end
               &lt;/select&gt;
             &lt;/dd&gt;
+            ## Option for including children, for non-terminal pages
+            #if($currentDocRef.name == $defaultPageName)
+              &lt;dt class="$hidden"&gt;
+                &lt;input type="checkbox" id="includeChildren" name="includeChildren" #if($currentDocRef.name == $defaultPageName)checked="checked" #end/&gt;
+                &lt;label for="includeChildren"&gt;$services.localization.render('PublicationWorkflow.PublicationWorkflowClass_includeChildren')&lt;/label&gt;
+              &lt;/dt&gt;
+            #end
             ## Terminal page - Advanced users.
             #set ($hidden = '')
             #if (!($isAdvancedUser || $isSuperAdmin) || $deprecatedSpaceCreate)

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,18 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.PublicationWorkflowMacro" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowMacro" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowMacro</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1360256286000</creationDate>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1360256286000</date>
-  <contentUpdateDate>1360256286000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <comment/>
@@ -55,8 +53,11 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
         <number>5</number>
@@ -70,7 +71,9 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </cache>
       <code>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
@@ -102,6 +105,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
         <number>3</number>
@@ -229,11 +234,14 @@ document.observe('xwiki:dom:loading', function() {
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
-        <number>6</number>
+        <number>5</number>
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -244,9 +252,11 @@ document.observe('xwiki:dom:loading', function() {
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </cache>
       <code>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>code</name>
-        <number>3</number>
+        <number>2</number>
         <prettyName>Code</prettyName>
         <rows>20</rows>
         <size>50</size>
@@ -257,9 +267,11 @@ document.observe('xwiki:dom:loading', function() {
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
-        <number>1</number>
+        <number>6</number>
         <prettyName>Content Type</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -272,7 +284,7 @@ document.observe('xwiki:dom:loading', function() {
       <name>
         <disabled>0</disabled>
         <name>name</name>
-        <number>2</number>
+        <number>1</number>
         <prettyName>Name</prettyName>
         <size>30</size>
         <unmodifiable>0</unmodifiable>
@@ -283,7 +295,7 @@ document.observe('xwiki:dom:loading', function() {
         <displayFormType>select</displayFormType>
         <displayType>yesno</displayType>
         <name>parse</name>
-        <number>5</number>
+        <number>4</number>
         <prettyName>Parse content</prettyName>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
@@ -292,9 +304,11 @@ document.observe('xwiki:dom:loading', function() {
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
-        <number>4</number>
+        <number>3</number>
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -387,10 +401,51 @@ document.observe('xwiki:dom:loading', function() {
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>12</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>13</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>11</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
       <code>
         <disabled>0</disabled>
+        <editor>Text</editor>
         <name>code</name>
-        <number>9</number>
+        <number>10</number>
         <prettyName>Macro code</prettyName>
         <rows>20</rows>
         <size>40</size>
@@ -398,23 +453,47 @@ document.observe('xwiki:dom:loading', function() {
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </code>
       <contentDescription>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>contentDescription</name>
-        <number>8</number>
+        <number>9</number>
         <prettyName>Content description (Not applicable for "No content" type)</prettyName>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </contentDescription>
+      <contentJavaType>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentJavaType</name>
+        <number>8</number>
+        <picker>1</picker>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentJavaType>
       <contentType>
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
         <number>7</number>
-        <prettyName>Macro content type</prettyName>
+        <prettyName>Macro content availability</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator>|</separator>
         <separators>|</separators>
@@ -433,7 +512,9 @@ document.observe('xwiki:dom:loading', function() {
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </defaultCategory>
       <description>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>description</name>
         <number>3</number>
         <prettyName>Macro description</prettyName>
@@ -474,6 +555,8 @@ document.observe('xwiki:dom:loading', function() {
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>visibility</name>
         <number>6</number>
@@ -487,6 +570,15 @@ document.observe('xwiki:dom:loading', function() {
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </visibility>
     </class>
+    <property>
+      <async_cached/>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled/>
+    </property>
     <property>
       <code>{{velocity}}
 #set($discard = $xwiki.ssx.use('PublicationWorkflow.PublicationWorkflowMacro'))
@@ -866,6 +958,9 @@ document.observe('xwiki:dom:loading', function() {
     </property>
     <property>
       <contentDescription/>
+    </property>
+    <property>
+      <contentJavaType/>
     </property>
     <property>
       <contentType>No content</contentType>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowPanel.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowPanel.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,18 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc version="1.4" reference="PublicationWorkflow.PublicationWorkflowPanel" locale="">
   <web>PublicationWorkflow</web>
   <name>PublicationWorkflowPanel</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357318493000</creationDate>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1357318493000</date>
-  <contentUpdateDate>1357318493000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <comment/>
@@ -53,17 +51,59 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>7</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>8</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>6</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
       <category>
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>category</name>
-        <number>5</number>
+        <number>1</number>
         <prettyName>Category</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>Information|Navigation|Tools|Administration|Other</values>
@@ -73,8 +113,8 @@
         <disabled>0</disabled>
         <editor>Text</editor>
         <name>content</name>
-        <number>4</number>
-        <prettyName>Content</prettyName>
+        <number>5</number>
+        <prettyName>Executed Content</prettyName>
         <rows>25</rows>
         <size>120</size>
         <unmodifiable>0</unmodifiable>
@@ -84,7 +124,7 @@
         <disabled>0</disabled>
         <editor>Text</editor>
         <name>description</name>
-        <number>3</number>
+        <number>2</number>
         <prettyName>Description</prettyName>
         <rows>5</rows>
         <size>40</size>
@@ -94,7 +134,7 @@
       <name>
         <disabled>0</disabled>
         <name>name</name>
-        <number>1</number>
+        <number>3</number>
         <prettyName>Name</prettyName>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -104,19 +144,30 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>type</name>
-        <number>2</number>
+        <number>4</number>
         <prettyName>Panel type</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>view|edit</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </type>
     </class>
+    <property>
+      <async_cached/>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled/>
+    </property>
     <property>
       <category>Information</category>
     </property>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Refusal.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Refusal.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,19 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc version="1.4" reference="PublicationWorkflow.Refusal" locale="">
   <web>PublicationWorkflow</web>
   <name>Refusal</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357836976000</creationDate>
   <parent>Main.SpaceIndex</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1358184399000</date>
-  <contentUpdateDate>1358184399000</contentUpdateDate>
   <version>1.1</version>
   <title>Refuser</title>
   <comment/>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,18 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.Script" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.Script" locale="">
   <web>PublicationWorkflow</web>
   <name>Script</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357556398000</creationDate>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1433937572000</date>
-  <contentUpdateDate>1524434369000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <comment/>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
@@ -81,6 +81,7 @@
   ## workflow doc ref: $workflowDocRef
   ## Action : $action
   #if($action == "start")
+    #set ($includeChildren = "$!request.includeChildren" != '')
     #set ($targetSpaceReferencePath = "$!request.targetSpace")
     #set ($targetName = "$!request.targetName")
     #set ($defaultSpaceHomePageName = $xwiki.getXWikiPreference('xwiki.defaultpage','WebHome'))
@@ -100,7 +101,7 @@
     #elseif($xwiki.exists($targetReference))
       $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', 'targetexists=true'))
     #else
-      #set($result = $services.publicationworkflow.startWorkflow($workflowDocRef, $workflowConfig, $targetReference))
+      #set($result = $services.publicationworkflow.startWorkflow($workflowDocRef, $includeChildren, $workflowConfig, $targetReference))
     #end
   #elseif($action == 'startastarget')
     #set($workflowConfig = "$!request.workflow")

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.de.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.de.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,24 +20,21 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.Translations" locale="de">
+<xwikidoc version="1.4" reference="PublicationWorkflow.Translations" locale="de">
   <web>PublicationWorkflow</web>
   <name>Translations</name>
   <language>de</language>
   <defaultLanguage>en</defaultLanguage>
   <translation>1</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357828638000</creationDate>
   <parent>Main.SpaceIndex</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1357828638000</date>
-  <contentUpdateDate>1357828638000</contentUpdateDate>
   <version>1.1</version>
   <title>Translations</title>
   <comment/>
   <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.1</syntaxId>
+  <syntaxId>plain/1.0</syntaxId>
   <hidden>true</hidden>
   <content>meeting.livetable.doc.title = Name des Workflows
 meeting.livetable.contributor = Autoren
@@ -159,39 +156,4 @@ workflow.overview.doc.title=Titel
 workflow.overview.doc.location=Ort
 workflow.overview.doc.author=Letzter Autor
 workflow.overview.doc.date=Datum</content>
-  <object>
-    <name>PublicationWorkflow.Translations</name>
-    <number>0</number>
-    <className>XWiki.TranslationDocumentClass</className>
-    <guid>5169bd63-2e30-45b9-862d-24d270c75bcc</guid>
-    <class>
-      <name>XWiki.TranslationDocumentClass</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <scope>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <multiSelect>0</multiSelect>
-        <name>scope</name>
-        <number>1</number>
-        <prettyName>Scope</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>GLOBAL|WIKI|USER|ON_DEMAND</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </scope>
-    </class>
-    <property>
-      <scope>WIKI</scope>
-    </property>
-  </object>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.fr.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.fr.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,24 +20,21 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.Translations" locale="fr">
+<xwikidoc version="1.4" reference="PublicationWorkflow.Translations" locale="fr">
   <web>PublicationWorkflow</web>
   <name>Translations</name>
   <language>fr</language>
   <defaultLanguage>en</defaultLanguage>
   <translation>1</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357828638000</creationDate>
   <parent>Main.SpaceIndex</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1357828638000</date>
-  <contentUpdateDate>1357828638000</contentUpdateDate>
   <version>1.1</version>
   <title>Translations</title>
   <comment/>
   <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.1</syntaxId>
+  <syntaxId>plain/1.0</syntaxId>
   <hidden>true</hidden>
   <content>meeting.livetable.doc.title = Nom du workflow
 meeting.livetable.contributor = Contributeurs
@@ -147,39 +144,4 @@ workflow.overview.doc.title=Titre
 workflow.overview.doc.location=Emplacement
 workflow.overview.doc.author=Dernier auteur
 workflow.overview.doc.date=Date</content>
-  <object>
-    <name>PublicationWorkflow.Translations</name>
-    <number>0</number>
-    <className>XWiki.TranslationDocumentClass</className>
-    <guid>5169bd63-2e30-45b9-862d-24d270c75bcc</guid>
-    <class>
-      <name>XWiki.TranslationDocumentClass</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <scope>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <multiSelect>0</multiSelect>
-        <name>scope</name>
-        <number>1</number>
-        <prettyName>Scope</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>GLOBAL|WIKI|USER|ON_DEMAND</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </scope>
-    </class>
-    <property>
-      <scope>WIKI</scope>
-    </property>
-  </object>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,24 +20,21 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.Translations" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.Translations" locale="">
   <web>PublicationWorkflow</web>
   <name>Translations</name>
   <language/>
   <defaultLanguage>en</defaultLanguage>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1423227662000</creationDate>
   <parent>Main.SpaceIndex</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1423227662000</date>
-  <contentUpdateDate>1423227662000</contentUpdateDate>
   <version>1.1</version>
   <title>Translations</title>
   <comment/>
   <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.1</syntaxId>
+  <syntaxId>plain/1.0</syntaxId>
   <hidden>true</hidden>
   <content>meeting.livetable.doc.title = Workflow Name
 meeting.livetable.contributor = Contributors
@@ -178,6 +175,8 @@ workflow.overview.doc.date=Date</content>
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>scope</name>
         <number>1</number>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.xml
@@ -88,6 +88,7 @@ PublicationWorkflow.PublicationWorkflowClass_status_validating = Currently being
 PublicationWorkflow.PublicationWorkflowClass_status_valid = Validated
 PublicationWorkflow.PublicationWorkflowClass_status_published = Published
 PublicationWorkflow.PublicationWorkflowClass_status_archived = Archived
+PublicationWorkflow.PublicationWorkflowClass_includeChildren=Include children
 PublicationWorkflow.PublicationWorkflowConfigClass_groupedit_hint = Edit Workflow Group
 PublicationWorkflow.PublicationWorkflowConfigClass_contributor = Contributors
 PublicationWorkflow.PublicationWorkflowConfigClass_moderator = Moderators
@@ -144,6 +145,8 @@ workflow.save.unpublish =  Creating draft from the published document {0}.
 workflow.save.backToDraft = Change the status to draft to allow editing.
 workflow.save.archive = Archive the document by {0}.
 workflow.save.publishFromArchive = Publication of the document from an archive by {0}.
+workflow.save.hide = Mark as hidden.
+workflow.save.unhide = Mark as unhidden.
 
 workflow.alert.publish = Are you sure you want to publish this document ?
 workflow.alert.archive = Are you sure you want to archive this document ?

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Unpublish.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Unpublish.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,19 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc version="1.4" reference="PublicationWorkflow.Unpublish" locale="">
   <web>PublicationWorkflow</web>
   <name>Unpublish</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357839341000</creationDate>
   <parent>PublicationWorkflow.PublicationWorkflowPanel</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1357839341000</date>
-  <contentUpdateDate>1357839341000</contentUpdateDate>
   <version>1.1</version>
   <title>Dépublier</title>
   <comment/>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/ValidationRefusalMailTemplate.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/ValidationRefusalMailTemplate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,29 +20,28 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc>
+<xwikidoc version="1.4" reference="PublicationWorkflow.ValidationRefusalMailTemplate" locale="">
   <web>PublicationWorkflow</web>
   <name>ValidationRefusalMailTemplate</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent/>
   <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
-  <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1358174916000</creationDate>
-  <date>1433937368000</date>
-  <contentUpdateDate>1433856579000</contentUpdateDate>
   <version>1.1</version>
   <title>ValidationRefusalMailTemplate</title>
-  <defaultTemplate/>
-  <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
+  <content>Modèle de mail à envoyer aux contributeurs lorsque les modérateurs ont refusé l'un de leurs documents</content>
   <object>
+    <name>PublicationWorkflow.ValidationRefusalMailTemplate</name>
+    <number>0</number>
+    <className>XWiki.Mail</className>
+    <guid>6fecc2c8-202a-4a43-84c8-819311a7fe24</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -53,7 +52,9 @@
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -81,7 +82,9 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -91,10 +94,6 @@
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.ValidationRefusalMailTemplate</name>
-    <number>0</number>
-    <className>XWiki.Mail</className>
-    <guid>6fecc2c8-202a-4a43-84c8-819311a7fe24</guid>
     <property>
       <html>Les modérateurs ont refusé de valider le document $document pour les raisons suivantes : $reason &lt;br&gt;
 Vous pouvez revenir au brouillon pour le modifier &lt;a href="$url"&gt;ici&lt;/a&gt;. 
@@ -115,6 +114,10 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
     </property>
   </object>
   <object>
+    <name>PublicationWorkflow.ValidationRefusalMailTemplate</name>
+    <number>1</number>
+    <className>XWiki.Mail</className>
+    <guid>04ed5f8a-5100-4a12-a25a-aef389b9f4eb</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -125,7 +128,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -153,7 +158,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -163,10 +170,6 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.ValidationRefusalMailTemplate</name>
-    <number>1</number>
-    <className>XWiki.Mail</className>
-    <guid>04ed5f8a-5100-4a12-a25a-aef389b9f4eb</guid>
     <property>
       <html>The moderators have refused to validate the document $document for the following reasons : $reason &lt;br&gt;
 In order to modify it, you can access the draft by clicking this &lt;a href="$url"&gt;link&lt;/a&gt;.
@@ -186,5 +189,4 @@ In order to modify it, you can access the draft by clicking this link : $url.
 This message has been automatically sent by XWiki.</text>
     </property>
   </object>
-  <content>Modèle de mail à envoyer aux contributeurs lorsque les modérateurs ont refusé l'un de leurs documents</content>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/ValidationRequestMailTemplate.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/ValidationRequestMailTemplate.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,29 +20,28 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc>
+<xwikidoc version="1.4" reference="PublicationWorkflow.ValidationRequestMailTemplate" locale="">
   <web>PublicationWorkflow</web>
   <name>ValidationRequestMailTemplate</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent/>
   <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
-  <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1358159178000</creationDate>
-  <date>1433937278000</date>
-  <contentUpdateDate>1433856578000</contentUpdateDate>
   <version>1.1</version>
   <title/>
-  <defaultTemplate/>
-  <validationScript/>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
+  <content>Modèle du mail envoyé aux modérateurs lorsqu'un article est soumis à la modération</content>
   <object>
+    <name>PublicationWorkflow.ValidationRequestMailTemplate</name>
+    <number>0</number>
+    <className>XWiki.Mail</className>
+    <guid>8fe0c8f0-9334-467a-8c1c-f8b09e2d40c1</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -53,7 +52,9 @@
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -81,7 +82,9 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -91,10 +94,6 @@
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.ValidationRequestMailTemplate</name>
-    <number>0</number>
-    <className>XWiki.Mail</className>
-    <guid>8fe0c8f0-9334-467a-8c1c-f8b09e2d40c1</guid>
     <property>
       <html>Le document $document a été soumis à la validation. Vous pouvez consulter sa version actuelle et le valider en suivant le lien qui suit : &lt;a href="$url"&gt;$document&lt;/a&gt;
 &lt;br&gt;&lt;br&gt;
@@ -113,6 +112,10 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
     </property>
   </object>
   <object>
+    <name>PublicationWorkflow.ValidationRequestMailTemplate</name>
+    <number>1</number>
+    <className>XWiki.Mail</className>
+    <guid>f182f5b4-56dc-46cd-ad6e-585d9e01bef5</guid>
     <class>
       <name>XWiki.Mail</name>
       <customClass/>
@@ -123,7 +126,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
       <nameField/>
       <validationScript/>
       <html>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>html</name>
         <number>4</number>
         <prettyName>HTML</prettyName>
@@ -151,7 +156,9 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </subject>
       <text>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>text</name>
         <number>3</number>
         <prettyName>Text</prettyName>
@@ -161,10 +168,6 @@ Ce courriel a été envoyé automatiquement par XWiki.</text>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </text>
     </class>
-    <name>PublicationWorkflow.ValidationRequestMailTemplate</name>
-    <number>1</number>
-    <className>XWiki.Mail</className>
-    <guid>f182f5b4-56dc-46cd-ad6e-585d9e01bef5</guid>
     <property>
       <html>The document $document has been submitted to validation. You can access the current version and validate it by clicking on &lt;a href="$url"&gt;$document&lt;/a&gt;.
 &lt;br&gt;&lt;br&gt;
@@ -182,5 +185,4 @@ This message has been automatically sent by XWiki.</html>
 This message has been automatically sent by XWiki.</text>
     </property>
   </object>
-  <content>Modèle du mail envoyé aux modérateurs lorsqu'un article est soumis à la modération</content>
 </xwikidoc>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/WebHome.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/WebHome.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,19 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="PublicationWorkflow.WebHome" locale="">
+<xwikidoc version="1.4" reference="PublicationWorkflow.WebHome" locale="">
   <web>PublicationWorkflow</web>
   <name>WebHome</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1357557002000</creationDate>
   <parent>Main.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1358262463000</date>
-  <contentUpdateDate>1358262463000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <comment/>


### PR DESCRIPTION
Hi all, Hi @lucaa, This pull request implements the ability to include chidren on publish. The first commit in the list performs an update of the pages and the API to xwiki-platform 12.10.4, while the next ones provide the implementation itself. Comments and reviews are welcome, thank you.