### PR TITLE
XAWORKFLOW-113: Allow to start a workflow from the target page

### DIFF
--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
@@ -74,7 +74,7 @@ public interface PublicationWorkflow
      * Starts the workflow on {@code target} as the published document, without creating the draft document. The draft
      * can be created the first time when the function {@link #createDraftDocument(DocumentReference, XWikiContext)}
      * will be called on this published document. Roughly this function is only setting up the marker on {@code target}
-     * as a published documemt. It does, however, all verifications (that there is no other worflow on that document,
+     * as a published documemt. It does, however, all verifications (that there is no other workflow on that document,
      * etc.).
      *
      * @param target the document reference on which the workflow will be started
@@ -92,7 +92,7 @@ public interface PublicationWorkflow
      * Starts the workflow on {@code target} as the published document, without creating the draft document. The draft
      * can be created the first time when the function {@link #createDraftDocument(DocumentReference, XWikiContext)}
      * will be called on this published document. Roughly this function is only setting up the marker on {@code target}
-     * as a published documemt. It does, however, all verifications (that there is no other worflow on that document,
+     * as a published documemt. It does, however, all verifications (that there is no other workflow on that document,
      * etc.).
      *
      * @param target the document reference on which the workflow will be started

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/PublicationWorkflow.java
@@ -76,15 +76,36 @@ public interface PublicationWorkflow
      * will be called on this published document. Roughly this function is only setting up the marker on {@code target}
      * as a published documemt. It does, however, all verifications (that there is no other worflow on that document,
      * etc.).
-     * 
-     * @param target
-     * @param workflowConfig
-     * @param xcontext
-     * @return
-     * @throws XWikiException
+     *
+     * @param target the document reference on which the workflow will be started
+     * @param workflowConfig the configuration information for the workflow
+     * @param xcontext the context information
+     * @return {@code true} if the workflow was successfully started on the specified target {@code false} otherwise
+     * @throws XWikiException if an exception occurs during the workflow process
+     * @deprecated use {@link #startWorkflowAsTarget(DocumentReference, boolean, String, XWikiContext)}
      */
+    @Deprecated
     boolean startWorkflowAsTarget(DocumentReference target, String workflowConfig, XWikiContext xcontext)
         throws XWikiException;
+
+    /**
+     * Starts the workflow on {@code target} as the published document, without creating the draft document. The draft
+     * can be created the first time when the function {@link #createDraftDocument(DocumentReference, XWikiContext)}
+     * will be called on this published document. Roughly this function is only setting up the marker on {@code target}
+     * as a published documemt. It does, however, all verifications (that there is no other worflow on that document,
+     * etc.).
+     *
+     * @param target the document reference on which the workflow will be started
+     * @param includeChildren {@code true} if the workflow should include child documents {@code false} otherwise
+     * @param workflowConfig the configuration information for the workflow
+     * @param xcontext the context information
+     * @return {@code true} if the workflow was successfully started on the specified target {@code false} otherwise
+     * @throws XWikiException if an exception occurs during the workflow process
+     *
+     * @since 2.4
+     */
+    boolean startWorkflowAsTarget(DocumentReference target, boolean includeChildren, String workflowConfig,
+        XWikiContext xcontext) throws XWikiException;
 
     /**
      * Gets the draft document corresponding to the passed target: meaning the workflow document which is not a target
@@ -122,10 +143,10 @@ public interface PublicationWorkflow
      * the defaultDraftsSpace property of the workflow config of the target and the name of the draft document is a
      * unique name generated starting from the target document.
      * 
-     * @param targetRef
-     * @param xcontext
-     * @return
-     * @throws XWikiException
+     * @param targetRef the reference to the target document for which a draft is being created
+     * @param xcontext the context information
+     * @return {@code true} if the draft document was successfully created {@code false} otherwise
+     * @throws XWikiException if an exceptions occurs during the workflow process
      */
     DocumentReference createDraftDocument(DocumentReference targetRef, XWikiContext xcontext)
         throws XWikiException;

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
@@ -141,44 +141,51 @@ public class PublicationWorkflowService implements ScriptService
     }
 
     /**
+     * Starts the workflow on {@code target} as the published document, without creating the draft document. The draft
+     * can be created the first time when the function {@link #createDraftDocument(DocumentReference)} will be called on
+     * this published document. Roughly this function is only setting up the marker on {@code target} as a published
+     * documemt. It does, however, all verifications (that there is no other workflow on that document, etc.).
      *
-     * @param doc the document reference on which the workflow will be started
+     * @param docRef the document reference on which the workflow will be started
      * @param workflowConfig the configuration information for the workflow
      * @return {@code true} if the workflow was successfully started on the specified target {@code false} otherwise
-     *
      * @deprecated use {@link #startWorkflowAsTarget(DocumentReference, boolean, String)}
      */
-    public boolean startWorkflowAsTarget(DocumentReference doc, String workflowConfig)
+    public boolean startWorkflowAsTarget(DocumentReference docRef, String workflowConfig)
     {
-        return startWorkflowAsTarget(doc, true, workflowConfig);
+        return startWorkflowAsTarget(docRef, true, workflowConfig);
     }
 
     /**
+     * Starts the workflow on {@code target} as the published document, without creating the draft document. The draft
+     * can be created the first time when the function {@link #createDraftDocument(DocumentReference)} will be called on
+     * this published document. Roughly this function is only setting up the marker on {@code target} as a published
+     * documemt. It does, however, all verifications (that there is no other workflow on that document, etc.).
      *
-     * @param doc the document reference on which the workflow will be started
+     * @param docRef the document reference on which the workflow will be started
      * @param includeChildren {@code true} if the workflow should include child documents {@code false} otherwise
      * @param workflowConfig the configuration information for the workflow
      * @return {@code true} if the workflow was successfully started on the specified target {@code false} otherwise
-     *
      * @since 2.4
      */
-    public boolean startWorkflowAsTarget(DocumentReference doc, boolean includeChildren, String workflowConfig)
+    public boolean startWorkflowAsTarget(DocumentReference docRef, boolean includeChildren, String workflowConfig)
     {
         XWikiContext xcontext = getXContext();
         try {
-            if (authManager.hasAccess(Right.EDIT, xcontext.getUserReference(), doc)) {
-                return this.publicationWorkflow.startWorkflowAsTarget(doc, includeChildren, workflowConfig, xcontext);
+            if (authManager.hasAccess(Right.EDIT, xcontext.getUserReference(), docRef)) {
+                return this.publicationWorkflow.startWorkflowAsTarget(docRef, includeChildren, workflowConfig,
+                    xcontext);
             } else {
                 // TODO: put error on context
                 return false;
             }
         } catch (XWikiException e) {
-            logger.warn("Could not start workflow for document {} and config {}", stringSerializer.serialize(doc),
+            logger.warn("Could not start workflow for document {} and config {}.", stringSerializer.serialize(docRef),
                 workflowConfig);
             // TODO: put error on context
             return false;
         }
-    }    
+    }
 
     public DocumentReference getDraftDocument(DocumentReference target)
     {
@@ -205,18 +212,28 @@ public class PublicationWorkflowService implements ScriptService
         }
     }
 
-    public DocumentReference createDraftDocument(DocumentReference target)
+    /**
+     * Creates a draft document corresponding to the passed target reference, which will have as a target the passed
+     * reference. The draft document is created in the same wiki, the space where the document is created is taken from
+     * the defaultDraftsSpace property of the workflow config of the target and the name of the draft document is a
+     * unique name generated starting from the target document.
+     *
+     * @param targetRef the reference to the target document for which a draft is being created
+     * @return {@code true} if the draft document was successfully created {@code false} otherwise
+     */
+    public DocumentReference createDraftDocument(DocumentReference targetRef)
     {
         XWikiContext xcontext = getXContext();
         try {
             if (this.publicationRoles.canContribute(xcontext.getUserReference(),
-                xcontext.getWiki().getDocument(target, xcontext), xcontext)) {
-                return this.publicationWorkflow.createDraftDocument(target, xcontext);
+                xcontext.getWiki().getDocument(targetRef, xcontext), xcontext))
+            {
+                return this.publicationWorkflow.createDraftDocument(targetRef, xcontext);
             } else {
                 return null;
             }
         } catch (XWikiException e) {
-            logger.warn("Could not create draft for target {}", stringSerializer.serialize(target));
+            logger.warn("Could not create draft for target {}", stringSerializer.serialize(targetRef));
             // TODO: put error on context
             return null;
         }

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowService.java
@@ -139,13 +139,35 @@ public class PublicationWorkflowService implements ScriptService
             return false;
         }
     }
-    
+
+    /**
+     *
+     * @param doc the document reference on which the workflow will be started
+     * @param workflowConfig the configuration information for the workflow
+     * @return {@code true} if the workflow was successfully started on the specified target {@code false} otherwise
+     *
+     * @deprecated use {@link #startWorkflowAsTarget(DocumentReference, boolean, String)}
+     */
     public boolean startWorkflowAsTarget(DocumentReference doc, String workflowConfig)
+    {
+        return startWorkflowAsTarget(doc, true, workflowConfig);
+    }
+
+    /**
+     *
+     * @param doc the document reference on which the workflow will be started
+     * @param includeChildren {@code true} if the workflow should include child documents {@code false} otherwise
+     * @param workflowConfig the configuration information for the workflow
+     * @return {@code true} if the workflow was successfully started on the specified target {@code false} otherwise
+     *
+     * @since 2.4
+     */
+    public boolean startWorkflowAsTarget(DocumentReference doc, boolean includeChildren, String workflowConfig)
     {
         XWikiContext xcontext = getXContext();
         try {
             if (authManager.hasAccess(Right.EDIT, xcontext.getUserReference(), doc)) {
-                return this.publicationWorkflow.startWorkflowAsTarget(doc, workflowConfig, xcontext);
+                return this.publicationWorkflow.startWorkflowAsTarget(doc, includeChildren, workflowConfig, xcontext);
             } else {
                 // TODO: put error on context
                 return false;

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/PublicationWorkflowMacro.xml
@@ -769,6 +769,11 @@ document.observe('xwiki:dom:loading', function() {
               &lt;input type="checkbox" id="targetIsTerminal" name="targetIsTerminal" #if($currentDocRef.name != $defaultPageName)checked="checked" #end/&gt;
               &lt;label for="terminal"&gt;$services.localization.render('core.create.terminal.label')&lt;/label&gt;
             &lt;/dt&gt;
+            &lt;dt&gt;
+              &lt;input type="checkbox" id="startAsTarget" name="startAsTarget"/&gt;
+              &lt;label for="startAsTarget"&gt;$escapetool.xml($services.localization.render('workflow.start.startAsTarget'))&lt;/label&gt;
+              &lt;span class="xHint"&gt;$escapetool.xml($services.localization.render('workflow.start.startAsTarget.hint'))&lt;/span&gt;
+            &lt;/dt&gt;
           &lt;/dl&gt;
           &lt;input type="hidden" name="action" value="start" /&gt;
           &lt;input type="hidden" name="workflowdoc" value="$escapetool.xml($services.model.serialize($currentDocRef, 'default'))" /&gt;
@@ -1069,7 +1074,7 @@ document.observe('xwiki:dom:loading', function() {
       <defaultValue>true</defaultValue>
     </property>
     <property>
-      <description></description>
+      <description/>
     </property>
     <property>
       <mandatory>0</mandatory>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Script.xml
@@ -82,37 +82,38 @@
   ## Action : $action
   #if($action == "start")
     #set ($includeChildren = "$!request.includeChildren" != '')
-    #set ($targetSpaceReferencePath = "$!request.targetSpace")
-    #set ($targetName = "$!request.targetName")
-    #set ($defaultSpaceHomePageName = $xwiki.getXWikiPreference('xwiki.defaultpage','WebHome'))
-    #set ($targetSpaceReference = $services.model.resolveSpace($targetSpaceReferencePath))
-    #if (!$request.targetIsTerminal &amp;&amp; $targetName != $defaultSpaceHomePageName)
-      #set ($targetSpaceReference = $services.model.createSpaceReference($targetName, $targetSpaceReference))
-      #set ($targetReference = $services.model.createDocumentReference($defaultSpaceHomePageName, $targetSpaceReference))
+    #set ($workflowConfig = "$!request.workflow")
+    #if ("$!request.startAsTarget" != '')
+      #if ($workflowConfig == '')
+        $response.sendRedirect($xwiki.getURL($redirectdoc, 'view', 'error=missingparams'))
+      #elseif(!$xwiki.exists($workflowDocRef))
+        $response.sendRedirect($xwiki.getURL($redirectdoc, 'view', 'error=targetdoesnotexist'))
+      #else
+        #set($result = $services.publicationworkflow.startWorkflowAsTarget($workflowDocRef, $includeChildren, $workflowConfig))
+        #if (!$result)
+          $response.sendRedirect($xwiki.getURL($redirectdoc, 'view', 'error=invalidpage'))
+        #end
+      #end
     #else
+      #set ($targetSpaceReferencePath = "$!request.targetSpace")
+      #set ($targetName = "$!request.targetName")
+      #set ($defaultSpaceHomePageName = $xwiki.getXWikiPreference('xwiki.defaultpage','WebHome'))
       #set ($targetSpaceReference = $services.model.resolveSpace($targetSpaceReferencePath))
-      #set ($targetReference = $services.model.createDocumentReference($targetName, $targetSpaceReference))
-    #end
-    #set($workflowConfig = "$request.workflow")
-    ## Check that the target and the existing doc are different
-    #if($targetReference.equals($workflowDocRef))
-      $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', 'same=true'))
-    ## Check that the target does not exist
-    #elseif($xwiki.exists($targetReference))
-      $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', 'targetexists=true'))
-    #else
-      #set($result = $services.publicationworkflow.startWorkflow($workflowDocRef, $includeChildren, $workflowConfig, $targetReference))
-    #end
-  #elseif($action == 'startastarget')
-    #set($workflowConfig = "$!request.workflow")
-    #if ($workflowConfig == '')
-      $response.sendRedirect($xwiki.getURL($redirectdoc, 'view', 'error=missingparams'))
-    #elseif(!$xwiki.exists($workflowDocRef))
-      $response.sendRedirect($xwiki.getURL($redirectdoc, 'view', 'error=targetdoesnotexist'))
-    #else
-      #set($result = $services.publicationworkflow.startWorkflowAsTarget($workflowDocRef, $workflowConfig))
-      #if (!$result)
-        $response.sendRedirect($xwiki.getURL($redirectdoc, 'view', 'error=invalidpage'))
+      #if (!$request.targetIsTerminal &amp;&amp; $targetName != $defaultSpaceHomePageName)
+        #set ($targetSpaceReference = $services.model.createSpaceReference($targetName, $targetSpaceReference))
+        #set ($targetReference = $services.model.createDocumentReference($defaultSpaceHomePageName, $targetSpaceReference))
+      #else
+        #set ($targetSpaceReference = $services.model.resolveSpace($targetSpaceReferencePath))
+        #set ($targetReference = $services.model.createDocumentReference($targetName, $targetSpaceReference))
+      #end
+      ## Check that the target and the existing doc are different
+      #if($targetReference.equals($workflowDocRef))
+        $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', 'same=true'))
+      ## Check that the target does not exist
+      #elseif($xwiki.exists($targetReference))
+        $response.sendRedirect($xwiki.getURL($workflowDocRef, 'view', 'targetexists=true'))
+      #else
+        #set($result = $services.publicationworkflow.startWorkflow($workflowDocRef, $includeChildren, $workflowConfig, $targetReference))
       #end
     #end
   #elseif ($action == "submitformoderation")

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Translations.xml
@@ -54,6 +54,8 @@ workflow.start.name.placeholder=TargetPage
 workflow.start.advancedoptions.text=Use the advanced options to select the location of the published page and the workflow configuration associated to this page.
 workflow.start.advancedoptions.button=Advanced options
 workflow.start.targetExists=Published page already exists.
+workflow.start.startAsTarget=Start as target
+workflow.start.startAsTarget.hint=Start workflow from the current page considering it the target
 
 workflow.title = Workflow
 workflow.currentStatus = Current status
@@ -143,6 +145,7 @@ workflow.overview.failValidate = A problem occurred during the validation of doc
 workflow.overview.failPublish = A problem occurred during the publication of document [[{0}]]
 
 workflow.save.start = Start workflow {0} on document {1}.
+workflow.save.startAsTarget = Start workflow {0} on document {1} as target.
 workflow.save.submitForModeration = Submit document {0} to moderation.
 workflow.save.refuseModeration = Moderation refused : {0}
 workflow.save.submitForValidation = Submit document {0} to validation.


### PR DESCRIPTION
# Jira URL
https://jira.xwiki.org/browse/XAWORKFLOW-113

# Changes
* add UI element to trigger the workflow start from target page
* add support for 'includeChildren'
* deprecate old method that doesn't support 'includeChildren'
* in the PublicationWorkflow.Script, the 'startAsTarget' code is handled as part of 'start' action and not as an independent one, using the same form submit button

# Screenshots
## Before
![image](https://github.com/user-attachments/assets/866a0900-e1f8-4f9f-a008-38725e653373)
## After
![image](https://github.com/user-attachments/assets/6650cd2b-bd33-4b5a-b6ae-b4f47cb34ac7)
