### PR TITLE
XAWORKFLOW-115: Move strategy is not working anymore

### DIFF
--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultWorkflowConfigManager.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/DefaultWorkflowConfigManager.java
@@ -50,7 +50,7 @@ public class DefaultWorkflowConfigManager implements WorkflowConfigManager
      * The current entity reference resolver, to resolve the notions class reference.
      */
     @Inject
-    @Named("current/reference")
+    @Named("current")
     protected DocumentReferenceResolver<EntityReference> currentReferenceEntityResolver;
 
     @Override

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowCopyListener.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowCopyListener.java
@@ -1,0 +1,107 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.workflowpublication.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.observation.EventListener;
+import org.xwiki.observation.event.Event;
+import org.xwiki.refactoring.event.DocumentCopiedEvent;
+import org.xwiki.refactoring.job.CopyRequest;
+import org.xwiki.workflowpublication.PublicationWorkflow;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Event listener to listen to document copy events and remove the workflow object from the copy, to avoid having two
+ * pages with the same target. We trust the person doing the copy to set up a new workflow if desired, instead of making
+ * guesses on our own.
+ *
+ * @version $Id$
+ * @since 1.9
+ */
+@Component
+@Named("PublicationWorkflowCopyListener")
+@Singleton
+public class PublicationWorkflowCopyListener implements EventListener
+{
+    private static final List<Event> EVENTS = Collections.singletonList(new DocumentCopiedEvent());
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private PublicationWorkflow publicationWorkflow;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.xwiki.observation.EventListener#getEvents()
+     */
+    public List<Event> getEvents()
+    {
+        return EVENTS;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.xwiki.observation.EventListener#getName()
+     */
+    public String getName()
+    {
+        return "PublicationWorkflowCopyListener";
+    }
+
+    public void onEvent(Event event, Object source, Object data)
+    {
+        XWikiContext context = contextProvider.get();
+        String wikiId = context.getWikiId();
+
+        try {
+            CopyRequest copyRequest = (CopyRequest) data;
+            DocumentReference workflowDestinationRef = (DocumentReference) copyRequest.getDestination();
+
+            // Set the context wiki to current wiki as the DocumentCopyingEvent is executed with the main wiki context.
+            context.setWikiId(Objects.requireNonNull(workflowDestinationRef).getWikiReference().getName());
+
+            XWikiDocument workflowDestinationDoc = context.getWiki().getDocument(workflowDestinationRef, context);
+            if (publicationWorkflow.isWorkflowDocument(workflowDestinationDoc, context)) {
+                workflowDestinationDoc.removeXObjects(publicationWorkflow.PUBLICATION_WORKFLOW_CLASS);
+            }
+        } catch (XWikiException e) {
+            throw new RuntimeException(e);
+        } finally {
+            // Set back the context wiki to original (main).
+            context.setWikiId(wikiId);
+        }
+    }
+}

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
@@ -121,7 +121,7 @@ public class PublicationWorkflowRenameListener implements EventListener
 
     private static final String WF_MOVE_STRATEGY_FIELD_NAME = "moveStrategy";
 
-    private final List<Event> eventsList = Collections.singletonList(new DocumentRenamedEvent());
+    private static final List<Event> EVENTS = Collections.singletonList(new DocumentRenamedEvent());
 
     @Inject
     private WorkflowConfigManager configManager;
@@ -169,7 +169,7 @@ public class PublicationWorkflowRenameListener implements EventListener
      */
     public List<Event> getEvents()
     {
-        return eventsList;
+        return EVENTS;
     }
 
     /**

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
@@ -190,6 +190,7 @@ public class PublicationWorkflowRenameListener implements EventListener
     public void onEvent(Event event, Object source, Object data)
     {
         XWikiContext context = contextProvider.get();
+        String wikiId = context.getWikiId();
 
         try {
             MoveRequest moveRequest = (MoveRequest) data;
@@ -240,6 +241,9 @@ public class PublicationWorkflowRenameListener implements EventListener
             }
         } catch (XWikiException e) {
             throw new RuntimeException(e);
+        } finally {
+            // Set back the context wiki to original (main).
+            context.setWikiId(wikiId);
         }
     }
 

--- a/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
+++ b/xwiki-workflow-publication-api/src/main/java/org/xwiki/workflowpublication/internal/PublicationWorkflowRenameListener.java
@@ -20,7 +20,6 @@
 package org.xwiki.workflowpublication.internal;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -28,15 +27,13 @@ import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
-import org.xwiki.bridge.event.DocumentCreatingEvent;
-import org.xwiki.bridge.event.DocumentDeletingEvent;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReference;
@@ -47,10 +44,12 @@ import org.xwiki.observation.event.Event;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryManager;
+import org.xwiki.refactoring.event.DocumentRenamedEvent;
+import org.xwiki.refactoring.job.MoveRequest;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.Right;
-import org.xwiki.workflowpublication.PublicationRoles;
 import org.xwiki.workflowpublication.PublicationWorkflow;
+import org.xwiki.workflowpublication.WorkflowConfigManager;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -63,22 +62,11 @@ import difflib.Patch;
 import difflib.PatchFailedException;
 
 /**
- * Event listener to listen to document copy or renaming events and update the target of the draft according to the new location.
- * 
- * Unfortunately it is not possible to clearly distinguish between a copy and a move/rename for baseline of the supported XWiki platform
- * (that is 7.2). In that version there is no DocumentRenamingEvent or DocumentCopyEvent (introduced in 11.1), instead a
- * move/rename shows as a DocumentCreatingEvent followed by a corresponding DocumentDeletingEvent, while a copy is just a DocumentCreatingEvent.
- *
- * So if we get noticed by a DocumentCreatedEvent that a document popped into existence with a Workflow already attached to it,
- * we assume it is a copy. However, we remember in the context that this document has been created with a certain targetDocument,
- * so we can change our mind if another document with the same target gets deleted in the same context; in that case we undo
- * the action we did for the copy and handle it as a move.
- *
+ * Event listener to listen to document rename events and update the target of the draft according to the new location.
+ * Also rename the children if the Preserve children option is checked in the Move/Rename wizard.
  * Currently, the action taken for the events is:
  *
  * <ul>
- *   <li> if the event is a copy, we remove the workflow object from the copy, to avoid having two pages with the same target.
- *     We trust the person doing the copy to set up a new workflow if desired, instead of making guesses on our own.
  *   <li> if the event is a rename/move and the document is a target, we instead update the targetDocument attribute
  *     in the workflow object to point to itself, and also update the targetDocument of the corresponding draft.
  *     Depending on the configuration of the workflow, drafts can also be moved automatically (see below).
@@ -87,8 +75,8 @@ import difflib.PatchFailedException;
  *    document gets published.
  *    Depending on the configuration of the workflow, the target can also be moved automatically (see below).
  * </ul>
- *
- * Depending on the configuration of the option WF_MOVE_STRATEGY_FIELDNAME in the workflow configuration, the
+ * <p>
+ * Depending on the configuration of the option WF_MOVE_STRATEGY_FIELD_NAME in the workflow configuration, the
  * listener can either :
  * <ul>
  *   <li>Move the equivalent documents of the document being moved, whatever this document is (draft or target)</li>
@@ -102,9 +90,9 @@ import difflib.PatchFailedException;
  * this computation fails, no move is attempted, and the user is informed through the move logs.
  * When performing such moves, the following parameters are checked :
  * <ul>
- *     <li>Verify that the equivalent document has not been moved already.</li>
- *     <li>Verify that the user performing the move has edit rights on the target space.</li>
- *     <li>Verify that no document already exists in the new location.</li>
+ *   <li>Verify that the equivalent document has not been moved already.</li>
+ *   <li>Verify that the user performing the move has edit rights on the target space.</li>
+ *   <li>Verify that no document already exists in the new location.</li>
  * </ul>
  *
  * @version $Id$
@@ -116,6 +104,27 @@ import difflib.PatchFailedException;
 public class PublicationWorkflowRenameListener implements EventListener
 {
 
+    private static final String WORKFLOW_EQUIVALENT = "workflowEquivalent";
+
+    private static final String TARGET = "target";
+
+    private static final String MOVE_STRATEGY_DO_NOTHING = "doNothing";
+
+    private static final String MOVE_STRATEGY_MOVE_TARGET_IF_UNPUBLISHED = "moveTargetIfUnpublished";
+
+    private static final String MOVE_STRATEGY_MOVE_TARGET = "moveTarget";
+
+    private static final String MOVE_STRATEGY_MOVE_DRAFTS = "moveDrafts";
+
+    private static final String MOVE_STRATEGY_MOVE_ALL = "moveAll";
+
+    private static final String WF_MOVE_STRATEGY_FIELD_NAME = "moveStrategy";
+
+    private final List<Event> eventsList = Collections.singletonList(new DocumentRenamedEvent());
+
+    @Inject
+    private WorkflowConfigManager configManager;
+
     /**
      * The logger to log.
      */
@@ -123,27 +132,20 @@ public class PublicationWorkflowRenameListener implements EventListener
     private Logger logger;
 
     @Inject
-    @Named("explicit")
-    protected DocumentReferenceResolver<EntityReference> explicitReferenceDocRefResolver;
+    private DocumentReferenceResolver<EntityReference> entityResolver;
 
     @Inject
-    protected DocumentReferenceResolver<String> defaultDocRefResolver;
+    private DocumentReferenceResolver<String> stringResolver;
 
     @Inject
     private QueryManager queryManager;
-
-    /**
-     * Reference string serializer for diagnostic messages, etc.
-     */
-    @Inject
-    protected EntityReferenceSerializer<String> stringSerializer;
 
     /**
      * Reference string serializer to be used to store the workflow target.
      */
     @Inject
     @Named("compactwiki")
-    protected EntityReferenceSerializer<String> compactWikiSerializer;
+    private EntityReferenceSerializer<String> compactWikiSerializer;
 
     /**
      * Used to check access rights when moving automatically equivalent documents.
@@ -151,65 +153,15 @@ public class PublicationWorkflowRenameListener implements EventListener
     @Inject
     private AuthorizationManager authorizationManager;
 
-    /**
-     * For translations.
-     */
     @Inject
-    private ContextualLocalizationManager localizationManager;
-
-    public static final String WF_CONFIG_REF_FIELDNAME = "workflow";
-
-    public static final String WF_TARGET_FIELDNAME = "target";
-
-    public final static String WF_STATUS_FIELDNAME = "status";
-
-    public final static String WF_IS_TARGET_FIELDNAME = "istarget";
-
-    public final static int DRAFT = 0;
-
-    public final static int PUBLISHED = 1;
-
-    public final static String STATUS_PUBLISHED = "published";
-
-    public static final String MOVE_STRATEGY_DO_NOTHING = "doNothing";
-
-    public static final String MOVE_STRATEGY_MOVE_TARGET_IF_UNPUBLISHED = "moveTargetIfUnpublished";
-
-    public static final String MOVE_STRATEGY_MOVE_TARGET = "moveTarget";
-
-    public static final String MOVE_STRATEGY_MOVE_DRAFTS = "moveDrafts";
-
-    public static final String MOVE_STRATEGY_MOVE_ALL = "moveAll";
-
-    //
-    // internal use: key names for data stored in the current context
-    //
-
-    private final static String TARGET_DOCUMENT_CREATED_REMARK = PublicationWorkflowRenameListener.class.getName() + ";targetcreated;";
-
-    private final static String DRAFT_DOCUMENT_CREATED_REMARK = PublicationWorkflowRenameListener.class.getName() + ";draftcreated;";
-
-    private final static String DOCREF_KEY = "doc";
-
-    private final static String WORKFLOW_KEY = "wf";
-
-    private final static String EQUIVALENT_DOCUMENT_MOVE_KEY = "publicationWorkflowEquivalentDocumentMove";
+    private PublicationWorkflow publicationWorkflow;
 
     @Inject
-    protected PublicationWorkflow publicationWorkflow;
-
-    @Inject
-    protected PublicationRoles publicationRoles;
-
-    /**
-     * The events observed by this observation manager.
-     */
-    private final List<Event> eventsList =
-        new ArrayList<>(Arrays.asList(new DocumentCreatingEvent(), new DocumentDeletingEvent()));
+    private Provider<XWikiContext> contextProvider;
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.xwiki.observation.EventListener#getEvents()
      */
     public List<Event> getEvents()
@@ -219,7 +171,7 @@ public class PublicationWorkflowRenameListener implements EventListener
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.xwiki.observation.EventListener#getName()
      */
     public String getName()
@@ -229,324 +181,251 @@ public class PublicationWorkflowRenameListener implements EventListener
 
     /**
      * (the include mace) {@inheritDoc}
-     * 
-     * @see org.xwiki.observation.EventListener#onEvent(org.xwiki.observation.event.Event, java.lang.Object,
-     *      java.lang.Object)
+     *
+     * @see EventListener#onEvent(Event, Object, Object)
      */
     public void onEvent(Event event, Object source, Object data)
     {
-        XWikiContext context = (XWikiContext) data;
-        XWikiDocument document = (XWikiDocument) source;
+        XWikiContext context = contextProvider.get();
 
-        if (event instanceof DocumentCreatingEvent) {
-            handleDocumentCreation(document, context);
-        } else if (event instanceof DocumentDeletingEvent) {
-            handleDocumentDeletion(document, context);
-        }
-    }
-
-    private void handleDocumentCreation(XWikiDocument currentDocument, XWikiContext context)
-    {
         try {
-            // Check if the new document is a workflow document
-            if (!publicationWorkflow.isWorkflowDocument(currentDocument, context)) {
-                return;
-            }
+            MoveRequest moveRequest = (MoveRequest) data;
+            DocumentReference workflowSourceRef =
+                (DocumentReference) moveRequest.getEntityReferences().stream().findFirst().orElse(null);
+            DocumentReference workflowDestinationRef = (DocumentReference) moveRequest.getDestination();
 
-            DocumentReference currentDocumentReference = currentDocument.getDocumentReference();
+            XWikiDocument workflowDoc = getWorkflowDocument(workflowSourceRef, workflowDestinationRef, context);
 
-            // Get the workflow object
-            BaseObject workflowInstance =
-                currentDocument.getXObject(explicitReferenceDocRefResolver.resolve(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS,
-                    currentDocumentReference));
+            if (publicationWorkflow.isWorkflowDocument(workflowDoc, context)) {
+                // Get the moving strategy.
+                BaseObject workflowConfig = configManager.getWorkflowConfigForWorkflowDoc(workflowDoc, context);
+                String moveStrategy = workflowConfig.getStringValue(WF_MOVE_STRATEGY_FIELD_NAME);
+                if (shouldProcessMoveStrategy(moveStrategy)) {
+                    DocumentRenamedEvent documentRenamedEvent = (DocumentRenamedEvent) event;
+                    DocumentReference currentSourceRef = documentRenamedEvent.getSourceReference();
+                    DocumentReference currentTargetRef = documentRenamedEvent.getTargetReference();
 
-            // Check if the document is published and is a target
-            if (StringUtils.equals(workflowInstance.getStringValue(WF_STATUS_FIELDNAME), STATUS_PUBLISHED)
-                && workflowInstance.getIntValue(WF_IS_TARGET_FIELDNAME) == PUBLISHED) {
-                // if we knew this is a move, we could handle it right away,
-                // but instead we must assume this is a copy
-                handleTargetDocumentCreation(currentDocument, workflowInstance, context);
-            } else
-                // or if it is a draft
-                if (workflowInstance.getIntValue(WF_IS_TARGET_FIELDNAME) == DRAFT) {
-                    handleDraftDocumentCreation(currentDocument, workflowInstance, context);
-            } else {
-                // TODO: what else might it be? an archived target maybe?
-                logger.warn("workflow document created at [{}] which is neither a draft or a published target; its workflow state is [{}]",
-                    stringSerializer.serialize(currentDocumentReference), workflowInstance.getIntValue(WF_IS_TARGET_FIELDNAME));
-            }
+                    boolean isTarget = workflowDoc.getIntValue("istarget") == 1;
 
-        } catch (XWikiException e) {
-            logger.warn("Could not get workflow config document for document [{}]",
-                stringSerializer.serialize(currentDocument.getDocumentReference()));
-        } catch (QueryException e) {
-            logger.warn("Could not get compagnion document (draft or target) for created document [{}]",
-                stringSerializer.serialize(currentDocument.getDocumentReference()));
-        }
-    }
-
-    private void handleDocumentDeletion(XWikiDocument doc, XWikiContext context)
-    {
-        final XWikiDocument document = doc.getOriginalDocument();
-        final DocumentReference documentReference = document.getDocumentReference();
-        final String documentReferenceString = stringSerializer.serialize(documentReference);
-        try {
-            // Check if the old document is a workflow document
-            if (!publicationWorkflow.isWorkflowDocument(document, context)) {
-                return;
-            }
-
-            logger.debug("document about to deleted is [{}]", documentReferenceString);
-
-            // Get the workflow object
-            BaseObject workflowInstance =
-                document.getXObject(explicitReferenceDocRefResolver.resolve(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS,
-                    documentReference));
-
-            // Check if the document is target and the current user can validate it
-            if (workflowInstance.getIntValue(WF_IS_TARGET_FIELDNAME) == PUBLISHED) {
-                // XXX: here we rather want to check rights for the draft reference, maybe?
-                if (publicationRoles.canValidate(context.getUserReference(), document, context)) {
-                    handleTargetDocumentDelete(documentReference, workflowInstance, context);
-                }
-            } else {
-                // or if it is not a target
-                if (workflowInstance.getIntValue(WF_IS_TARGET_FIELDNAME) == DRAFT) {
-                    handleDraftDocumentDelete(documentReference, workflowInstance, context);
-                }
-            }
-
-        } catch (XWikiException e) {
-            logger.warn("Could not get workflow config document for deleted document [{}]", documentReferenceString);
-        } catch (QueryException e) {
-            logger.warn("Could not get companion document (draft or target)for deleted document [{}]", documentReferenceString);
-        }
-    }
-
-    private void handleTargetDocumentCreation(XWikiDocument targetDoc, BaseObject workflowInstance, XWikiContext context)
-        throws XWikiException, QueryException
-    {
-        // we first check if there is another target document;
-        // if it is, and we are not the "right" target, only then delete the workflow
-        // otherwise we are in a first "publish" step, a XAR import or wiki creation
-        final DocumentReference targetDocRef = targetDoc.getDocumentReference();
-        final String targetDocFullName = this.compactWikiSerializer.serialize(targetDocRef);
-        final String serializedTargetName = workflowInstance.getStringValue(WF_TARGET_FIELDNAME);
-        if (targetDocFullName.equals(serializedTargetName)) {
-            // we are the "right" target. skip even querying for other target documents
-            return;
-        }
-        List<String> results = getDraftOrTargetPagesForWorkflow(serializedTargetName, true);
-        results.remove(targetDocFullName);
-        if (results.isEmpty()) {
-            return;
-        }
-
-        logger.debug("remember workflow from [{}] in case we need it again", stringSerializer.serialize(targetDocRef) );
-        rememberTargetDocumentCreated(targetDocRef, workflowInstance, context);
-        targetDoc.removeXObject(workflowInstance);
-    }
-
-    private void handleTargetDocumentDelete(DocumentReference oldTargetDoc, BaseObject oldWorkflowInstance, XWikiContext context)
-        throws QueryException, XWikiException
-    {
-        String serializedOldTargetName = oldWorkflowInstance.getStringValue(WF_TARGET_FIELDNAME);
-
-        // see if we have a recently created document with the same workflow target
-        // which should be updated to the new target (itself)
-        Map<String, Object> backupData = hasTargetDocumentBeenCreated(serializedOldTargetName, context);
-
-        if (backupData == null) {
-            // it seems the target document really got deleted :(
-            // what do we do now? tell the draft document about it?
-            return;
-        }
-        DocumentReference newTargetDocumentReference = (DocumentReference) backupData.get(DOCREF_KEY);
-        String serializedNewTargetName = compactWikiSerializer.serialize(newTargetDocumentReference, context.getWiki());
-        BaseObject backupOfWorkflowInstance = (BaseObject)backupData.get(WORKFLOW_KEY);
-
-        // ... as long as it actually exists
-        final XWiki xwiki = context.getWiki();
-        XWikiDocument newTargetDocument  = xwiki.getDocument(newTargetDocumentReference, context);
-        if (newTargetDocument.isNew()) {
-            logger.warn("could not find moved version [{}] of about to deleted target document [{}]", serializedNewTargetName,
-                stringSerializer.serialize(oldTargetDoc));
-            return;
-        }
-
-        // and the current user can validate it
-        if (!publicationRoles.canValidate(context.getUserReference(), newTargetDocument, context)) {
-            logger.warn("moved document at [{}] should have target updated, but the current user has insufficient rights to do this.",
-                stringSerializer.serialize(newTargetDocumentReference));
-            return;
-        }
-
-        newTargetDocument.setXObject(0, backupOfWorkflowInstance);
-        BaseObject newWorkflowInstance = newTargetDocument.getXObject(explicitReferenceDocRefResolver.resolve(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS,
-            newTargetDocumentReference));
-
-        // Set the current document as target
-        newWorkflowInstance.setStringValue(WF_TARGET_FIELDNAME, serializedNewTargetName);
-
-        // now we need to save the new document, as we are already in the deletion step of the other document
-        String defaultMoveMessage = "Update the workflow target from "+serializedOldTargetName +" to " + serializedNewTargetName + ".";
-        String moveMessage =
-            getMessage("workflow.move.updateTarget", defaultMoveMessage, Arrays.asList(serializedOldTargetName, serializedNewTargetName));
-
-        context.getWiki().saveDocument(newWorkflowInstance.getOwnerDocument(), moveMessage, true, context);
-
-        // Searching for the draft
-        List<String> results = getDraftOrTargetPagesForWorkflow(serializedOldTargetName, false);
-
-        // Update the target value in the draft(s)
-        // maybe we should check for permissions here, too?
-        for (String result : results) {
-            DocumentReference docRef = this.defaultDocRefResolver.resolve(result, context.getWikiReference());
-            XWikiDocument draftDocument = context.getWiki().getDocument(docRef, context);
-
-            // Get the workflow object
-            BaseObject draftWorkflowInstance =
-                draftDocument.getXObject(explicitReferenceDocRefResolver.resolve(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS,
-                    newTargetDocumentReference));
-            draftWorkflowInstance.setStringValue(WF_TARGET_FIELDNAME, serializedNewTargetName);
-
-            // Save the draft document
-            String defaultMessage =
-                String.format("The target was moved / renamed. Set the new location to [%s].", serializedNewTargetName);
-            String message = getMessage("workflow.move.updateDraft", defaultMessage,
-                Collections.singletonList(serializedNewTargetName));
-            context.getWiki().saveDocument(draftDocument, message, false, context);
-
-            String moveStrategy = getMoveStrategy(draftWorkflowInstance);
-            if (moveStrategy != null
-                && (moveStrategy.equals(MOVE_STRATEGY_MOVE_ALL) || moveStrategy.equals(MOVE_STRATEGY_MOVE_DRAFTS))
-                && !(context.containsKey(EQUIVALENT_DOCUMENT_MOVE_KEY)
-                     && context.get(EQUIVALENT_DOCUMENT_MOVE_KEY).equals(true))) {
-                // Try to move the given draft to a new location in order to match the move performed on the target
-                // document
-                DocumentReference newDraftDocumentReference = computeNewEquivalentDocumentReference(oldTargetDoc,
-                    newTargetDocumentReference, docRef, context);
-
-                if (!newDraftDocumentReference.equals(docRef)) {
-                    if (tryToMoveEquivalentDocument(oldTargetDoc,
-                        newTargetDocumentReference, docRef, newDraftDocumentReference, context)) {
-                        logger.info("The draft document [{}] has been moved to [{}]", docRef,
-                            newDraftDocumentReference);
-                    } else {
-                        logger.warn("The draft document [{}] could not be moved", docRef);
+                    switch (moveStrategy) {
+                        case MOVE_STRATEGY_MOVE_TARGET:
+                            if (!isTarget) {
+                                handlePublished(workflowDoc, workflowSourceRef, currentSourceRef, currentTargetRef,
+                                    true, context);
+                            }
+                        case MOVE_STRATEGY_MOVE_ALL:
+                            handlePublished(workflowDoc, workflowSourceRef, currentSourceRef, currentTargetRef,
+                                !isTarget, context);
+                            break;
+                        case MOVE_STRATEGY_MOVE_DRAFTS:
+                            if (isTarget) {
+                                handlePublished(workflowDoc, workflowSourceRef, currentSourceRef, currentTargetRef,
+                                    false, context);
+                            }
+                            break;
+                        case MOVE_STRATEGY_MOVE_TARGET_IF_UNPUBLISHED:
+                            if (!isTarget) {
+                                handleUnPublished(workflowDoc, workflowSourceRef, currentSourceRef, currentTargetRef,
+                                    context);
+                            }
+                            break;
                     }
                 }
             }
+        } catch (XWikiException e) {
+            throw new RuntimeException(e);
         }
     }
 
-    private void handleDraftDocumentCreation(XWikiDocument currentDocument, BaseObject workflowInstance,
-        XWikiContext context) throws QueryException
+    private void handleUnPublished(XWikiDocument workflowDoc, DocumentReference workflowSourceRef,
+        DocumentReference currentSourceRef, DocumentReference currentTargetRef, XWikiContext context)
+        throws XWikiException
     {
-        // we first check if there is another draft document;
-        // only if it is, assume a copy and delete the workflow
-        // otherwise we are a XAR import, wiki creation or maybe create from template
-        final String currentDocumentFullName = this.compactWikiSerializer.serialize(currentDocument.getDocumentReference());
-        final String serializedTargetName = workflowInstance.getStringValue(WF_TARGET_FIELDNAME);
-        List<String> results = getDraftOrTargetPagesForWorkflow(serializedTargetName, false);
-        results.remove(currentDocumentFullName);
-        if (results.isEmpty()) {
-            return;
-        }
+        BaseObject workflowObj =
+            workflowDoc.getXObject(entityResolver.resolve(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS));
+        String workflowEquivalent = workflowObj.getStringValue(TARGET);
+        DocumentReference workflowEquivalentRef = stringResolver.resolve(workflowEquivalent);
 
-        // as there is another document having the same target, we assume a copy
-        // and remove the workflow object from this document.
-        // we keep a copy of it in the current context in case the other document
-        // is deleted with the same context
-        logger.debug("remember workflow from draft [{}] in case we need it again", stringSerializer.serialize(currentDocument.getDocumentReference()) );
-        rememberDraftDocumentCreated(currentDocument.getDocumentReference(), workflowInstance, context);
-        currentDocument.removeXObject(workflowInstance);
-    }
-
-    private void handleDraftDocumentDelete(DocumentReference oldDraftDoc, BaseObject oldWorkflowInstance,
-        XWikiContext context) throws QueryException, XWikiException
-    {
-        String serializedOldTargetName = oldWorkflowInstance.getStringValue(WF_TARGET_FIELDNAME);
-
-        // look if we have a recently created draft
-        Map<String, Object> backupData = hasDraftDocumentBeenCreated(serializedOldTargetName, context);
-
-        if (backupData == null) {
-            // it seems the draft document really got deleted :(
-            // what do we do now? tell the target document about it?
-            return;
-        }
-        DocumentReference newDraftDocumentReference = (DocumentReference) backupData.get(DOCREF_KEY);
-        BaseObject backupOfWorkflowInstance = (BaseObject)backupData.get(WORKFLOW_KEY);
-
-        // which should actually exist
-        final XWiki xwiki = context.getWiki();
-        XWikiDocument newDraftDocument = xwiki.getDocument(newDraftDocumentReference, context);
-        if (newDraftDocument.isNew()) {
-            logger.debug("could not find moved version [{}] of about to deleted draft document [{}]", stringSerializer.serialize(newDraftDocumentReference),
-                stringSerializer.serialize(oldDraftDoc));
-            return;
-        }
-
-        // then we set (restore) the workflow object for it
-        logger.debug("restore workflow for moved draft [{}]", stringSerializer.serialize(newDraftDocumentReference) );
-        newDraftDocument.setXObject(0, backupOfWorkflowInstance);
-        backupOfWorkflowInstance = newDraftDocument.getXObject(explicitReferenceDocRefResolver.resolve(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS,
-            newDraftDocumentReference));
-
-        // TODO: Add option to silently update the moved / renamed document without creating a new version
-        String defaultSaveMessage = "Restore workflow object after rename of draft document with target " + serializedOldTargetName + '.';
-        String saveMessage =
-            getMessage("workflow.move.restoreWorkflowOnDraftAfterMove", defaultSaveMessage, null);
-        context.getWiki().saveDocument(newDraftDocument, saveMessage, true, context);
-
-        String moveStrategy = getMoveStrategy(backupOfWorkflowInstance);
-
-        if (moveStrategy != null
-            && !moveStrategy.equals(MOVE_STRATEGY_DO_NOTHING)
-            && !(context.containsKey(EQUIVALENT_DOCUMENT_MOVE_KEY)
-                 && context.get(EQUIVALENT_DOCUMENT_MOVE_KEY).equals(true))) {
-            DocumentReference oldTargetReference = defaultDocRefResolver.resolve(serializedOldTargetName);
-            DocumentReference newTargetReference = computeNewEquivalentDocumentReference(oldDraftDoc,
-                newDraftDocumentReference, oldTargetReference, context);
-
-            // Verify that we have been able to compute the new target name
-            if (!newTargetReference.equals(oldTargetReference)) {
-                if (xwiki.exists(oldTargetReference, context)
-                    && (moveStrategy.equals(MOVE_STRATEGY_MOVE_ALL) || moveStrategy.equals(MOVE_STRATEGY_MOVE_TARGET)))
-                {
-                    if (tryToMoveEquivalentDocument(oldDraftDoc, newDraftDocumentReference,
-                        oldTargetReference, newTargetReference, context)) {
-                        logger.info("The target document [{}] has been moved to [{}]", oldTargetReference,
-                            newTargetReference);
-                    } else {
-                        logger.warn("The target document [{}] could not be moved", oldTargetReference);
-                    }
-                } else if (moveStrategy.equals(MOVE_STRATEGY_MOVE_TARGET_IF_UNPUBLISHED)) {
-                    backupOfWorkflowInstance.set(WF_TARGET_FIELDNAME,
-                        compactWikiSerializer.serialize(newTargetReference, context.getWiki()), context);
-
-                    // TODO: Improve save message for this particular case
-                    context.getWiki().saveDocument(newDraftDocument, saveMessage, true, context);
-                }
+        if (!context.getWiki().exists(workflowEquivalentRef, context)) {
+            DocumentReference oldEquivalentRef =
+                computeEquivalentDocRef(workflowSourceRef, workflowEquivalentRef,
+                    currentSourceRef, context);
+            if (oldEquivalentRef.equals(workflowEquivalentRef)) {
+                DocumentReference newEquivalentRef =
+                    computeEquivalentDocRef(currentSourceRef, currentTargetRef,
+                        oldEquivalentRef,
+                        context);
+                maybeRenameEquivalentDocument(workflowObj, null, workflowEquivalentRef, oldEquivalentRef,
+                    newEquivalentRef, currentTargetRef, false, true, context);
             }
+        }
+    }
+
+    private void handlePublished(XWikiDocument workflowDoc, DocumentReference workflowSourceRef,
+        DocumentReference currentSourceRef, DocumentReference currentTargetRef, boolean isEquivalentTarget,
+        XWikiContext context)
+        throws XWikiException
+    {
+        BaseObject workflowObj =
+            workflowDoc.getXObject(entityResolver.resolve(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS));
+        String workflowEquivalent = getOrSetWorkflowEquivalent(workflowObj, isEquivalentTarget, context);
+        DocumentReference workflowEquivalentRef = stringResolver.resolve(workflowEquivalent);
+
+        DocumentReference oldEquivalentRef =
+            computeEquivalentDocRef(workflowSourceRef, workflowEquivalentRef, currentSourceRef, context);
+        DocumentReference newEquivalentRef =
+            computeEquivalentDocRef(currentSourceRef, currentTargetRef, oldEquivalentRef, context);
+
+        maybeRenameEquivalentDocument(workflowObj, workflowDoc.getTitle(), workflowEquivalentRef, oldEquivalentRef,
+            newEquivalentRef, currentTargetRef, true, isEquivalentTarget, context);
+    }
+
+    private void maybeRenameEquivalentDocument(BaseObject workflowObj, String workflowDocTitle,
+        DocumentReference workflowEquivalentRef, DocumentReference oldEquivalentRef, DocumentReference newEquivalentRef,
+        DocumentReference currentTargetRef, boolean isPublished, boolean isEquivalentTarget, XWikiContext context)
+        throws XWikiException
+    {
+        if (oldEquivalentRef.equals(workflowEquivalentRef)) {
+            XWikiDocument oldEquivalentDoc = context.getWiki().getDocument(oldEquivalentRef, context);
+            oldEquivalentDoc.setTitle(workflowDocTitle);
+            DocumentReference newWorkFlowTargetRef = currentTargetRef;
+            if (isEquivalentTarget) {
+                newWorkFlowTargetRef = newEquivalentRef;
+            }
+            workflowObj.setStringValue(TARGET, compactWikiSerializer.serialize(newWorkFlowTargetRef));
+            BaseObject equivalentWorkflowObj =
+                oldEquivalentDoc.getXObject(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS);
+            equivalentWorkflowObj.setStringValue(TARGET, compactWikiSerializer.serialize(newWorkFlowTargetRef));
+        }
+
+        if (isPublished) {
+            renameEquivalentDocument(oldEquivalentRef, newEquivalentRef, context);
         }
     }
 
     /**
-     * Based on the provided references, will try to compute the new equivalent document reference of the old
-     * equivalent document reference.
+     * Retrieves the workflow equivalent from the context, or sets it if not already present.
+     * <p>
+     * If the workflow equivalent is not already stored in the context, this method determines the value based on
+     * whether the document is a target or not. If the document is a target, it fetches the value from the workflow
+     * object using the {@code TARGET} field. If it's not a target, the method calls
+     * {@link #getEquivalentDraft(DocumentReference)} to compute the equivalent draft. The determined value is then
+     * stored in the context and returned.
      *
-     * @param oldCurrentDocumentReference the old reference of the document that is currently being moved
-     * @param newCurrentDocumentReference the new reference of the document that is currently being moved
-     * @param oldEquivalentDocumentReference the new reference of the equivalent document
-     * @param context the current context
-     * @return the reference of the new equivalent document reference. If this reference could not be computed, the
-     * old equivalent document reference is returned.
+     * @param workflowObj the workflow object containing workflow metadata
+     * @param isTarget {@code true} if the document is a target, {@code false} if it's a draft
+     * @param context the current XWiki context, which may hold the workflow equivalent
+     * @return the workflow equivalent, either fetched from the context or computed and stored in the context
      */
-    private DocumentReference computeNewEquivalentDocumentReference(DocumentReference oldCurrentDocumentReference,
-        DocumentReference newCurrentDocumentReference, DocumentReference oldEquivalentDocumentReference,
+    private String getOrSetWorkflowEquivalent(BaseObject workflowObj, boolean isTarget, XWikiContext context)
+    {
+        if (StringUtils.isEmpty((String) context.get(WORKFLOW_EQUIVALENT))) {
+            String workflowEquivalent;
+            if (isTarget) {
+                workflowEquivalent = workflowObj.getStringValue(TARGET);
+            } else {
+                workflowEquivalent = getEquivalentDraft(workflowObj.getOwnerDocument().getDocumentReference());
+            }
+            context.put(WORKFLOW_EQUIVALENT, workflowEquivalent);
+            return workflowEquivalent;
+        }
+        return (String) context.get(WORKFLOW_EQUIVALENT);
+    }
+
+    /**
+     * Retrieves the workflow document based on the source and destination references. This method first attempts to
+     * fetch the workflow document using the source reference. If the document is not identified as a workflow document
+     * (e.g., after it has been renamed), the method fetches the document using the destination reference instead.
+     *
+     * @param workflowSourceDocRef the reference to the source document of the workflow
+     * @param workflowDestinationDocRef the reference to the destination document of the workflow
+     * @param context the current XWiki context used to retrieve documents and other wiki-specific data
+     * @return the workflow document, either from the source or destination reference
+     * @throws XWikiException if an error occurs while retrieving the document
+     */
+    private XWikiDocument getWorkflowDocument(DocumentReference workflowSourceDocRef,
+        DocumentReference workflowDestinationDocRef, XWikiContext context) throws XWikiException
+    {
+        XWiki xwiki = context.getWiki();
+        XWikiDocument workflowDoc = xwiki.getDocument(workflowSourceDocRef, context);
+        // After the workflow doc's rename, we should consider the new document to get information for
+        // children's rename.
+        if (!publicationWorkflow.isWorkflowDocument(workflowDoc, context)) {
+            workflowDoc = xwiki.getDocument(workflowDestinationDocRef, context);
+        }
+        return workflowDoc;
+    }
+
+    private boolean shouldProcessMoveStrategy(String moveStrategy)
+    {
+        return StringUtils.isNotEmpty(moveStrategy) && !MOVE_STRATEGY_DO_NOTHING.equals(moveStrategy);
+    }
+
+    /**
+     * Renames or moves a document from an old document reference to a new document reference under certain conditions:
+     * <ul>
+     *   <li>The old document must exist.</li>
+     *   <li>The new document must not already exist to avoid overwriting.</li>
+     *   <li>The user performing the operation must have edit rights on the new document reference.</li>
+     * </ul>
+     * <p>
+     * If any of these conditions are not met, the document is not moved and appropriate warnings or info messages are logged.
+     *
+     * @param oldDocRef the reference to the existing document to be renamed or moved
+     * @param newDocRef the reference to the new location for the document
+     * @param context the XWikiContext, providing context and execution environment information for the operation
+     * @throws XWikiException If an error occurs during the rename operation
+     */
+    private void renameEquivalentDocument(DocumentReference oldDocRef, DocumentReference newDocRef,
         XWikiContext context)
+        throws XWikiException
+    {
+        XWiki xwiki = context.getWiki();
+        // Check if the old equivalent document exists.
+        if (!xwiki.exists(oldDocRef, context)) {
+            logger.info("The equivalent document [{}] does not exist anymore", oldDocRef);
+            return;
+        }
+
+        // Check if the new equivalent document exists.
+        if (xwiki.exists(newDocRef, context)) {
+            logger.warn("Cannot move [{}] to destination [{}] as a document already exists on this location",
+                oldDocRef, newDocRef);
+            return;
+        }
+
+        // Check if the user performing the move has edit rights on the new document reference.
+        if (!authorizationManager.hasAccess(Right.EDIT, context.getUserReference(), newDocRef)) {
+            logger.warn("Cannot move [{}] to destination [{}] as the current user [{}] has no edit rights on the "
+                    + "destination document", oldDocRef, newDocRef,
+                context.getUserReference());
+            return;
+        }
+
+        xwiki.renameDocument(oldDocRef, newDocRef, true, Collections.emptyList(), Collections.emptyList(), context);
+    }
+
+    /**
+     * Computes the new equivalent document reference based on the differences between the old and new references of the
+     * current document. This method attempts to generate a new reference for an equivalent document by applying the
+     * same changes that were made to the current document reference to the equivalent document reference.
+     * <p>
+     * If the reference cannot be computed (e.g., due to patch failure), the old equivalent document reference is
+     * returned.
+     * <p>
+     * The method operates by creating a diff between the old and new current document references and then attempts to
+     * apply this diff to the old equivalent document reference. If the patch applies correctly and results in a valid
+     * document name, the new equivalent reference is returned.
+     *
+     * @param oldCurrentDocRef the reference to the current document before it was moved
+     * @param newCurrentDocRef the reference to the current document after it was moved
+     * @param oldEquivalentDocRef the reference to the equivalent document before the move
+     * @param context the current XWikiContext, providing the execution environment and wiki information
+     * @return the new equivalent document reference if successfully computed; otherwise, the old equivalent document
+     *     reference
+     */
+    private DocumentReference computeEquivalentDocRef(DocumentReference oldCurrentDocRef,
+        DocumentReference newCurrentDocRef, DocumentReference oldEquivalentDocRef, XWikiContext context)
     {
         // Compare the differences between the original draft and target references
         // One option would be to do a three-way merge with :
@@ -560,22 +439,22 @@ public class PublicationWorkflowRenameListener implements EventListener
 
         // Start by splitting the different document references into an array of strings, which will be easier
         // to diff.
-        List<String> oldCurrentSplittedReference = createSplitReference(oldCurrentDocumentReference);
-        List<String> newCurrentSplittedReference = createSplitReference(newCurrentDocumentReference);
-        List<String> oldEquivalentSplittedReference = createSplitReference(oldEquivalentDocumentReference);
+        List<String> oldCurrentSplittedReference = createSplitReference(oldCurrentDocRef);
+        List<String> newCurrentSplittedReference = createSplitReference(newCurrentDocRef);
+        List<String> oldEquivalentSplittedReference = createSplitReference(oldEquivalentDocRef);
 
-        // Create the patch and try to apply it
+        // Create the patch and try to apply it.
         Patch<String> patch = DiffUtils.diff(oldCurrentSplittedReference, newCurrentSplittedReference);
         List<String> newEquivalentSplittedReference;
         try {
             newEquivalentSplittedReference = DiffUtils.patch(oldEquivalentSplittedReference, patch);
         } catch (PatchFailedException e) {
-            logger.warn("Unable to compute new location for the document [{}]", oldEquivalentDocumentReference);
+            logger.warn("Unable to compute new location for the document [{}]", oldEquivalentDocRef);
             logger.debug("Error when applying patch : [{}]", ExceptionUtils.getRootCause(e), e);
-            return oldEquivalentDocumentReference;
+            return oldEquivalentDocRef;
         }
 
-        // Reconstruct the new equivalent reference
+        // Reconstruct the new equivalent reference.
         String newEquivalentName = newEquivalentSplittedReference.get(newEquivalentSplittedReference.size() - 1);
         newEquivalentSplittedReference.remove(newEquivalentSplittedReference.size() - 1);
 
@@ -583,71 +462,9 @@ public class PublicationWorkflowRenameListener implements EventListener
     }
 
     /**
-     * Will try to move the equivalent document of the one provided in parameter to a new location.
-     * This method applies when the draft or the target is moved somewhere else, and we need to also need to move
-     * the corresponding draft or target.
-     *
-     * @param oldCurrentDocumentReference the old reference of the document that is currently being moved
-     * @param newCurrentDocumentReference the new reference of the document that is currently being moved
-     * @param oldEquivalentDocumentReference the old reference of the equivalent document
-     * @param newEquivalentDocumentReference the new reference of the equivalent document
-     * @param context the current context
-     * @return true if the move happened, false otherwise
-     */
-    private boolean tryToMoveEquivalentDocument(DocumentReference oldCurrentDocumentReference,
-        DocumentReference newCurrentDocumentReference, DocumentReference oldEquivalentDocumentReference,
-        DocumentReference newEquivalentDocumentReference, XWikiContext context)
-    {
-        // Conditions for moving / renaming the other document
-        // * The other document should exist (maybe it has already been renamed)
-        // * The other document should not overwrite another document present on its new document reference
-        // * The user executing the rename should have edit rights on the new document reference of the equivalent
-        // document
-        XWiki xwiki = context.getWiki();
-
-        // Check if the old equivalent document exists
-        if (!xwiki.exists(oldEquivalentDocumentReference, context)) {
-            logger.info("The equivalent document [{}] does not exist anymore", oldEquivalentDocumentReference);
-            return false;
-        }
-
-        // Check if the new equivalent document exists
-        if (xwiki.exists(newEquivalentDocumentReference, context)
-            || newEquivalentDocumentReference.equals(newCurrentDocumentReference)) {
-            logger.warn("Cannot move [{}] to destination [{}] as a document already exists on this location",
-                oldEquivalentDocumentReference, newEquivalentDocumentReference);
-            return false;
-        }
-
-        // Check if the user performing the move has edit rights on the new document reference
-        if (!authorizationManager.hasAccess(Right.EDIT, context.getUserReference(), newEquivalentDocumentReference)) {
-            logger.warn("Cannot move [{}] to destination [{}] as the current user [{}] has no edit rights on the "
-                + "destination document", oldEquivalentDocumentReference, newEquivalentDocumentReference,
-                context.getUserReference());
-            return false;
-        }
-
-        try {
-            // Before doing the rename of a document, we'll add a key in the context indicating that this move
-            // was triggered by this event listener, so that we do not end up in a loop.
-            context.put(EQUIVALENT_DOCUMENT_MOVE_KEY, true);
-            logger.info("Moving equivalent document [{}] to destination [{}]", oldEquivalentDocumentReference,
-                newEquivalentDocumentReference);
-            xwiki.renameDocument(oldEquivalentDocumentReference, newEquivalentDocumentReference, true, null, null,
-                context);
-            context.remove(EQUIVALENT_DOCUMENT_MOVE_KEY);
-        } catch (Exception e) {
-            logger.error("Failed to move [{}] to destination [{}]", oldEquivalentDocumentReference,
-                newEquivalentDocumentReference, e);
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * From the given document reference, create a list that contains the reversed reference chain of this document,
      * with the exclusion of the wiki reference.
+     * <p>
      * Example : with a document "A.B.C.D.WebHome", the list will be ['A', 'B', 'C', 'D', 'WebHome']
      *
      * @param reference the reference to use
@@ -667,118 +484,31 @@ public class PublicationWorkflowRenameListener implements EventListener
     }
 
     /**
-     * helper to look up either the draft or the target document.
-     * in either case try to find the page(s) that have a workflow document which &quot;target&quot; attribute
-     * points to given target name.
-     * @param targetName the serialized target document name
-     * @param isTarget if true, find target, otherwise find draft
+     * helper to look up either the draft or the target document. in either case try to find the page(s) that have a
+     * workflow document which &quot;target&quot; attribute points to given target name.
+     *
+     * @param targetRef the serialized target document name
      * @return a list of documentReferences (as strings); should usually contain at most one element
-     * @throws QueryException if an error occurred during the query execution
      */
-    private List<String> getDraftOrTargetPagesForWorkflow(String targetName, boolean isTarget)
-        throws QueryException
+    private String getEquivalentDraft(DocumentReference targetRef)
     {
-        // Searching for the draft
+        // Searching for the draft.
         Map<String, Object> queryParams = new HashMap<>();
         String workflowsQuery =
             "select obj.name from BaseObject obj, StringProperty target, IntegerProperty istarget "
                 + "where obj.className = :className and obj.id = target.id.id and target.id.name = 'target' and "
                 + "target.value = :target and obj.id = istarget.id.id and istarget.id.name = 'istarget' and "
-                + "istarget.value = :istarget";
+                + "istarget.value = 0";
 
         queryParams.put("className", compactWikiSerializer.serialize(PublicationWorkflow.PUBLICATION_WORKFLOW_CLASS));
-        queryParams.put(WF_TARGET_FIELDNAME, targetName);
-        queryParams.put(WF_IS_TARGET_FIELDNAME, isTarget ? PUBLISHED : DRAFT);
+        queryParams.put(TARGET, compactWikiSerializer.serialize(targetRef));
 
-        Query query = queryManager.createQuery(workflowsQuery, Query.HQL);
-        query.bindValues(queryParams);
-        return query.execute();
-    }
-
-    /**
-     * @param key Translation key
-     * @param params Parameters to include in the translation
-     * @param defaultMessage Message to display if the message tool finds no translation
-     * @return message to use
-     */
-    protected String getMessage(String key, String defaultMessage, List<String> params)
-    {
-        String message = (params == null)
-            ? localizationManager.getTranslationPlain(key)
-            : localizationManager.getTranslationPlain(key, params.toArray());
-        if (message == null || message.equals(key)) {
-            message = defaultMessage;
-        }
-        // trim the message, whichever that is, to 1023 characters, otherwise we're in trouble
-        if (message.length() > 1023) {
-            // add some dots to show that it was trimmed
-            message = message.substring(0, 1020) + "...";
-        }
-        return message;
-    }
-
-    /**
-     * From the given {@link BaseObject}, returns the move strategy chosen as part of the workflow configuration.
-     *
-     * @param workflowObject the object to use for getting the configuration
-     * @return the move strategy of the workflow, null if the workflow configuration could not be loaded
-     */
-    private String getMoveStrategy(BaseObject workflowObject)
-    {
         try {
-            List<String> result = queryManager.createQuery(
-                "select moveStrategy.value from BaseObject configObj, StringProperty moveStrategy "
-                    + "where configObj.name = :configFullName and configObj.className = "
-                    + "'PublicationWorkflow.PublicationWorkflowConfigClass' and moveStrategy.id.name = 'moveStrategy' "
-                    + "and configObj.id = moveStrategy.id.id",
-                Query.HQL)
-                .bindValue("configFullName", workflowObject.getStringValue(WF_CONFIG_REF_FIELDNAME))
-                .setLimit(1).execute();
-
-            if (result.size() == 1) {
-                return result.get(0);
-            } else {
-                logger.error("Could not fetch the move strategy of the workflow object [{}]",
-                    workflowObject.getDocumentReference());
-                return null;
-            }
+            Query query = queryManager.createQuery(workflowsQuery, Query.HQL);
+            query.bindValues(queryParams);
+            return (String) query.execute().get(0);
         } catch (QueryException e) {
-            logger.error("Failed to load the move strategy of the workflow object [{}]",
-                workflowObject.getDocumentReference(), e);
-            return null;
+            throw new RuntimeException(e);
         }
-    }
-
-    //
-    // helpers to remember previous events in the same context
-    //
-
-    private void rememberTargetDocumentCreated(DocumentReference targetDoc, BaseObject workflowInstance, XWikiContext context)
-    {
-        Map<String, Object> data = new HashMap<>();
-        data.put(DOCREF_KEY, targetDoc);
-        data.put(WORKFLOW_KEY, workflowInstance.duplicate());
-        context.put(TARGET_DOCUMENT_CREATED_REMARK + workflowInstance.getStringValue(WF_TARGET_FIELDNAME), data);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> hasTargetDocumentBeenCreated(String serializedTargetName, XWikiContext context)
-    {
-        return (Map<String, Object>) context.get(TARGET_DOCUMENT_CREATED_REMARK + serializedTargetName);
-    }
-
-    private void rememberDraftDocumentCreated(DocumentReference draftDocRef, BaseObject workflowInstance,
-        XWikiContext context)
-    {
-        Map<String, Object> data = new HashMap<>();
-        data.put(DOCREF_KEY, draftDocRef);
-        data.put(WORKFLOW_KEY, workflowInstance.duplicate());
-        context.put(DRAFT_DOCUMENT_CREATED_REMARK + workflowInstance.getStringValue(WF_TARGET_FIELDNAME), data);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> hasDraftDocumentBeenCreated(String serializedTargetName, XWikiContext context)
-    {
-        return (Map<String, Object>) context.get(DRAFT_DOCUMENT_CREATED_REMARK + serializedTargetName);
     }
 }

--- a/xwiki-workflow-publication-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-workflow-publication-api/src/main/resources/META-INF/components.txt
@@ -5,4 +5,5 @@ org.xwiki.workflowpublication.internal.DefaultPublicationRoles
 org.xwiki.workflowpublication.internal.DefaultWorkflowConfigManager
 org.xwiki.workflowpublication.internal.PublicationWorkflowEventsGeneratorListener
 org.xwiki.workflowpublication.internal.ReferencesTransformDocPublishingEventListener
+org.xwiki.workflowpublication.internal.PublicationWorkflowCopyListener
 org.xwiki.workflowpublication.internal.PublicationWorkflowRenameListener


### PR DESCRIPTION
# Jira URL
https://jira.xwiki.org/browse/XAWORKFLOW-115

# Changes
## Description
* Refactor the entire code to use the `DocumentRenamedEvent` event available since 11.x

## Clarifications
* Previously, it was not possible to distinguish between Copy and Rename/Move actions due to the lack of related events implemented in XWiki.
* With the old implementation, the only way to make the Rename/Move action to happen on a workflow document, following the move strategy, was to set the `refactoring.rename.useAtomicRename` to `false` in `xwiki.properties`.
Since `15.6-RC1` the `refactoring.rename.useAtomicRename` property is not available anymore (See https://jira.xwiki.org/browse/XWIKI-21044)