### PR TITLE
Changes to build against the latest version of XWiki

### DIFF
--- a/xwiki-workflow-publication-application/pom.xml
+++ b/xwiki-workflow-publication-application/pom.xml
@@ -45,10 +45,10 @@
       <groupId>org.xwiki.contrib.workflow-publication</groupId>
       <artifactId>xwiki-workflow-publication-api</artifactId>
       <version>${project.version}</version>
-    </dependency>
+    </dependency>	
   </dependencies>
   <build>
-    <plugins>
+    <plugins>  
       <plugin>
         <groupId>org.xwiki.commons</groupId>
         <artifactId>xwiki-commons-tool-xar-plugin</artifactId>
@@ -59,6 +59,19 @@
           </visibleTechnicalPages>
         </configuration>
       </plugin>
+        <!-- The version of Spoon and Spoon Maven plugin to use -->
+        <plugin>
+          <groupId>fr.inria.gforge.spoon</groupId>
+          <artifactId>spoon-maven-plugin</artifactId>
+          <version>3.8.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>fr.inria.gforge.spoon</groupId>
+              <artifactId>spoon-core</artifactId>
+              <version>${spoon.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>      
     </plugins>
   </build>
 </project>

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Overview.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/Overview.xml
@@ -35,7 +35,7 @@
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
-  <hidden>false</hidden>
+  <hidden>true</hidden>
   <content>{{velocity}}
 #* display all documents in a given workflow state.
  * @param $status the status in which the displayed workflow documents should be

--- a/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/WebHome.xml
+++ b/xwiki-workflow-publication-application/src/main/resources/PublicationWorkflow/WebHome.xml
@@ -35,7 +35,7 @@
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
-  <hidden>false</hidden>
+  <hidden>true</hidden>
   <content>{{velocity}}
 
 #set($columns = ["doc.title", "contributor", "moderator", "validator"])


### PR DESCRIPTION
I was planning on making some other changes, but first I needed to adjust to be able to even build this.

There was an issue with the spoon plug-in where module enforcement prevented the build.

There are rules that technical pages need to be hidden. 